### PR TITLE
[Chore] Add glossary, annotate models, and switch to StandardRB

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,0 @@
-# Omakase Ruby styling for Rails
-inherit_gem: { rubocop-rails-omakase: rubocop.yml }
-
-# Overwrite or add rules to create your own house style
-#
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,2 @@
+require:
+  - standard-rails

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "tailwindcss-rails"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[windows jruby]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
@@ -46,7 +46,7 @@ gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
 
   # Audits gems for known security defects (use config/bundler-audit.yml to ignore issues)
   gem "bundler-audit", require: false
@@ -54,8 +54,10 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-  gem "rubocop-rails-omakase", require: false
+  # StandardRB — zero-config Ruby linting [https://github.com/standardrb/standard]
+  gem "standardrb", require: false
+  gem "standard", ">= 1.35.1", require: false
+  gem "standard-rails", require: false
 
   # Testing
   gem "rspec-rails"
@@ -66,4 +68,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Annotate models with schema comments [https://github.com/drwl/annotaterb]
+  gem "annotaterb", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    annotaterb (4.22.0)
+      activerecord (>= 6.0.0)
+      activesupport (>= 6.0.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
@@ -294,7 +297,7 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
-    rubocop (1.86.0)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -318,10 +321,6 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
-    rubocop-rails-omakase (1.1.0)
-      rubocop (>= 1.72)
-      rubocop-performance (>= 1.24)
-      rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
@@ -352,6 +351,23 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    standard (1.54.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.84.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.8)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.9.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.26.0)
+    standard-rails (1.6.0)
+      lint_roller (~> 1.0)
+      rubocop-rails (~> 2.34.0)
+    standardrb (1.0.1)
+      standard
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -404,6 +420,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-postgis-adapter
+  annotaterb
   bootsnap
   brakeman
   bundler-audit
@@ -418,11 +435,13 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.3)
   rspec-rails
-  rubocop-rails-omakase
   shoulda-matchers
   solid_cable
   solid_cache
   solid_queue
+  standard (>= 1.35.1)
+  standard-rails
+  standardrb
   stimulus-rails
   tailwindcss-rails
   thruster

--- a/app/models/boil_water_summary.rb
+++ b/app/models/boil_water_summary.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: boil_water_summaries
+#
+#  id                       :bigint           not null, primary key
+#  date_range_display       :string
+#  download_url             :string
+#  first_advisory_date      :string
+#  last_advisory_date       :string
+#  pwsid                    :string           not null
+#  state                    :string
+#  state_reporting_year_max :string
+#  state_reporting_year_min :string
+#  tooltip_text             :text
+#  total_notices            :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_boil_water_summaries_on_pwsid  (pwsid) UNIQUE
+#
 class BoilWaterSummary < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :boil_water_summary
 

--- a/app/models/cartographic_county.rb
+++ b/app/models/cartographic_county.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: cartographic_counties
+#
+#  countyfp :string(3)
+#  geoid    :string(5)
+#  geom     :geometry         multipolygon, 4326
+#  gid      :integer          not null, primary key
+#  name     :string
+#  namelsad :string
+#  statefp  :string(2)
+#  stusps   :string(2)
+#
+# Indexes
+#
+#  index_cartographic_counties_on_geom                 (geom) USING gist
+#  index_cartographic_counties_on_namelsad_and_stusps  (namelsad,stusps)
+#
 class CartographicCounty < ApplicationRecord
   self.primary_key = "gid"
 end

--- a/app/models/cartographic_place.rb
+++ b/app/models/cartographic_place.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: cartographic_places
+#
+#  affgeoid :string
+#  geoid    :string(7)
+#  geom     :geometry         multipolygon, 4326
+#  gid      :integer          not null, primary key
+#  name     :string
+#  namelsad :string
+#  placefp  :string(5)
+#  statefp  :string(2)
+#  stusps   :string(2)
+#
+# Indexes
+#
+#  index_cartographic_places_on_affgeoid  (affgeoid)
+#  index_cartographic_places_on_geoid     (geoid)
+#  index_cartographic_places_on_geom      (geom) USING gist
+#
 class CartographicPlace < ApplicationRecord
   self.primary_key = "gid"
 

--- a/app/models/cartographic_state.rb
+++ b/app/models/cartographic_state.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: cartographic_states
+#
+#  geoid   :string(2)
+#  geom    :geometry         multipolygon, 4326
+#  gid     :integer          not null, primary key
+#  name    :string
+#  statefp :string(2)
+#  stusps  :string(2)
+#
+# Indexes
+#
+#  index_cartographic_states_on_geom  (geom) USING gist
+#
 class CartographicState < ApplicationRecord
   self.primary_key = "gid"
 end

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -180,7 +180,7 @@ module Filterable
       # --- Bounding box geographic filter ---
       if params[:bounds].present?
         west, south, east, north = params[:bounds].split(",").map(&:to_f)
-        scope, joined = left_join_once(scope, joined, :service_area_geometry)
+        scope, _ = left_join_once(scope, joined, :service_area_geometry)
         scope = scope.where(
           "ST_Intersects(service_area_geometries.geom, ST_MakeEnvelope(?, ?, ?, ?, 4326))",
           west, south, east, north
@@ -195,9 +195,9 @@ module Filterable
     # Adds a left outer join for the given association at most once per query,
     # preventing duplicate joins when multiple filters reference the same table.
     def left_join_once(scope, joined, assoc)
-      return [ scope, joined ] if joined.include?(assoc)
+      return [scope, joined] if joined.include?(assoc)
 
-      [ scope.left_joins(assoc), joined | [ assoc ] ]
+      [scope.left_joins(assoc), joined | [assoc]]
     end
   end
 end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: data_imports
+#
+#  id          :bigint           not null, primary key
+#  file_url    :string           not null
+#  imported_at :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_data_imports_on_file_url  (file_url)
+#
 class DataImport < ApplicationRecord
   validates :file_url, presence: true
   validates :imported_at, presence: true

--- a/app/models/demographic.rb
+++ b/app/models/demographic.rb
@@ -1,3 +1,45 @@
+# == Schema Information
+#
+# Table name: demographics
+#
+#  id                               :bigint           not null, primary key
+#  age_over_61_rate                 :decimal(5, 2)
+#  age_under_5_rate                 :decimal(5, 2)
+#  aian_rate                        :decimal(5, 2)
+#  asian_rate                       :decimal(5, 2)
+#  bachelors_degree_rate            :decimal(5, 2)
+#  black_rate                       :decimal(5, 2)
+#  hispanic_rate                    :decimal(5, 2)
+#  household_income_lowest_quintile :integer
+#  median_household_income          :integer
+#  mixed_race_rate                  :decimal(5, 2)
+#  most_common_rate_tier            :string
+#  napi_rate                        :decimal(5, 2)
+#  no_health_insurance_rate         :decimal(5, 2)
+#  other_race_rate                  :decimal(5, 2)
+#  owner_rate                       :decimal(5, 2)
+#  poc_rate                         :decimal(5, 2)
+#  population_density               :decimal(, )
+#  population_in_poverty_rate       :decimal(5, 2)
+#  poverty_rate                     :decimal(5, 2)
+#  pwsid                            :string           not null
+#  renter_rate                      :decimal(5, 2)
+#  total_population                 :integer
+#  unemployment_rate                :decimal(5, 2)
+#  water_rate_125_249               :decimal(5, 2)
+#  water_rate_250_499               :decimal(5, 2)
+#  water_rate_500_749               :decimal(5, 2)
+#  water_rate_750_999               :decimal(5, 2)
+#  water_rate_over_1000             :decimal(5, 2)
+#  water_rate_under_125             :decimal(5, 2)
+#  white_rate                       :decimal(5, 2)
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_demographics_on_pwsid  (pwsid) UNIQUE
+#
 class Demographic < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :demographic
 

--- a/app/models/environmental_justice.rb
+++ b/app/models/environmental_justice.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: environmental_justices
+#
+#  id                             :bigint           not null, primary key
+#  cejst_disadvantaged_pct        :decimal(5, 2)
+#  cejst_lead_paint_indicator     :integer
+#  cejst_low_life_expectancy_pctl :decimal(, )
+#  cvi_cancer_risk                :decimal(, )
+#  cvi_life_expectancy            :decimal(, )
+#  cvi_overall_score              :decimal(5, 2)
+#  cvi_redlining                  :decimal(, )
+#  ejscreen_disability_rate       :decimal(, )
+#  ejscreen_drinking_water        :decimal(, )
+#  pwsid                          :string           not null
+#  svi_overall_pctl               :decimal(5, 2)
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#
+# Indexes
+#
+#  index_environmental_justices_on_pwsid  (pwsid) UNIQUE
+#
 class EnvironmentalJustice < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :environmental_justice
 

--- a/app/models/funding_summary.rb
+++ b/app/models/funding_summary.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: funding_summaries
+#
+#  id                          :bigint           not null, primary key
+#  median_srf_assistance       :decimal(, )
+#  pwsid                       :string           not null
+#  times_funded                :integer
+#  total_principal_forgiveness :decimal(, )
+#  total_srf_assistance        :decimal(, )
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#
+# Indexes
+#
+#  index_funding_summaries_on_pwsid  (pwsid) UNIQUE
+#
 class FundingSummary < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :funding_summary
 

--- a/app/models/place_system_crosswalk.rb
+++ b/app/models/place_system_crosswalk.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: place_system_crosswalks
+#
+#  id                       :bigint           not null, primary key
+#  fraction_of_place        :decimal(, )
+#  fraction_of_service_area :decimal(, )
+#  geoid                    :string(7)        not null
+#  pwsid                    :string           not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_place_system_crosswalks_on_geoid_and_pwsid  (geoid,pwsid) UNIQUE
+#  index_place_system_crosswalks_on_pwsid            (pwsid)
+#
 class PlaceSystemCrosswalk < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid"
   belongs_to :cartographic_place, foreign_key: "geoid", primary_key: "geoid"

--- a/app/models/public_water_system.rb
+++ b/app/models/public_water_system.rb
@@ -1,3 +1,43 @@
+# == Schema Information
+#
+# Table name: public_water_systems
+#
+#  area_sq_miles                :decimal(, )
+#  counties                     :text
+#  detailed_facility_report     :string
+#  ewg_report_link              :string
+#  first_reported_date          :string
+#  gw_sw_code                   :string
+#  is_grant_eligible            :boolean
+#  is_school_or_daycare         :boolean
+#  is_wholesaler                :boolean
+#  open_health_viol             :string
+#  owner_type                   :string
+#  phone_number                 :string
+#  pop_cat_5                    :string
+#  population_served_count      :integer
+#  primacy_agency               :string
+#  primacy_type                 :string
+#  primary_source_code          :string
+#  pws_name                     :string
+#  pwsid                        :string           not null, primary key
+#  service_area_type            :string
+#  service_connections_count    :integer
+#  source_water_protection_code :string
+#  stusps                       :string(2)
+#  symbology_field              :string
+#  years_operating              :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#
+# Indexes
+#
+#  index_public_water_systems_on_gw_sw_code    (gw_sw_code)
+#  index_public_water_systems_on_owner_type    (owner_type)
+#  index_public_water_systems_on_pop_cat_5     (pop_cat_5)
+#  index_public_water_systems_on_primacy_type  (primacy_type)
+#  index_public_water_systems_on_stusps        (stusps)
+#
 class PublicWaterSystem < ApplicationRecord
   include Filterable
 
@@ -14,5 +54,5 @@ class PublicWaterSystem < ApplicationRecord
   has_many :place_system_crosswalks, foreign_key: "pwsid", dependent: :destroy
   has_many :cartographic_places, through: :place_system_crosswalks
 
-  validates :pwsid, presence: true, format: { with: /\A[A-Z]{2}\d{7}\z/ }
+  validates :pwsid, presence: true, format: {with: /\A[A-Z]{2}\d{7}\z/}
 end

--- a/app/models/service_area_geometry.rb
+++ b/app/models/service_area_geometry.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: service_area_geometries
+#
+#  id         :bigint           not null, primary key
+#  centroid   :geometry         point, 4326
+#  geom       :geometry         multipolygon, 4326
+#  pwsid      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_service_area_geometries_on_centroid  (centroid) USING gist
+#  index_service_area_geometries_on_geom      (geom) USING gist
+#  index_service_area_geometries_on_pwsid     (pwsid) UNIQUE
+#
 class ServiceAreaGeometry < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :service_area_geometry
 

--- a/app/models/tile_cache.rb
+++ b/app/models/tile_cache.rb
@@ -1,6 +1,20 @@
+# == Schema Information
+#
+# Table name: tile_cache
+#
+#  layer :string           not null, primary key
+#  mvt   :binary
+#  x     :integer          not null, primary key
+#  y     :integer          not null, primary key
+#  z     :integer          not null, primary key
+#
+# Indexes
+#
+#  index_tile_cache_on_z_and_x_and_y  (z,x,y)
+#
 class TileCache < ApplicationRecord
   self.table_name = "tile_cache"
-  self.primary_key = [ :layer, :z, :x, :y ]
+  self.primary_key = [:layer, :z, :x, :y]
 
   validates :layer, presence: true
   validates :z, presence: true

--- a/app/models/trend_datum.rb
+++ b/app/models/trend_datum.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: trend_data
+#
+#  id                               :bigint           not null, primary key
+#  households_pct_change            :decimal(, )
+#  income_change_flag               :string
+#  lowest_quintile_pct_change       :decimal(, )
+#  mhi_pct_change                   :decimal(, )
+#  mhi_pct_change_capped            :decimal(, )
+#  poc_pct_change                   :decimal(, )
+#  population_change_flag           :string
+#  population_in_poverty_pct_change :decimal(, )
+#  population_pct_change            :decimal(, )
+#  population_pct_change_capped     :decimal(, )
+#  poverty_pct_change               :decimal(, )
+#  pwsid                            :string           not null
+#  unemployment_pct_change          :decimal(, )
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_trend_data_on_pwsid  (pwsid) UNIQUE
+#
 class TrendDatum < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :trend_datum
 

--- a/app/models/violations_summary.rb
+++ b/app/models/violations_summary.rb
@@ -1,3 +1,43 @@
+# == Schema Information
+#
+# Table name: violations_summaries
+#
+#  id                               :bigint           not null, primary key
+#  groundwater_rule_10yr            :integer
+#  groundwater_rule_5yr             :integer
+#  health_violations_10yr           :integer
+#  health_violations_5yr            :integer
+#  inorganic_chemicals_10yr         :integer
+#  inorganic_chemicals_5yr          :integer
+#  lead_and_copper_10yr             :integer
+#  lead_and_copper_5yr              :integer
+#  paperwork_violations_10yr        :integer
+#  paperwork_violations_5yr         :integer
+#  pwsid                            :string           not null
+#  radionuclides_10yr               :integer
+#  radionuclides_5yr                :integer
+#  stage_1_disinfectants_10yr       :integer
+#  stage_1_disinfectants_5yr        :integer
+#  stage_2_disinfectants_10yr       :integer
+#  stage_2_disinfectants_5yr        :integer
+#  surface_water_treatment_10yr     :integer
+#  surface_water_treatment_5yr      :integer
+#  synthetic_organic_chemicals_10yr :integer
+#  synthetic_organic_chemicals_5yr  :integer
+#  total_coliform_10yr              :integer
+#  total_coliform_5yr               :integer
+#  total_violations_10yr            :integer
+#  total_violations_5yr             :integer
+#  violations_all_years             :integer
+#  volatile_organic_chemicals_10yr  :integer
+#  volatile_organic_chemicals_5yr   :integer
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_violations_summaries_on_pwsid  (pwsid) UNIQUE
+#
 class ViolationsSummary < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :violations_summary
 

--- a/app/models/watershed_hazard.rb
+++ b/app/models/watershed_hazard.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: watershed_hazards
+#
+#  id                              :bigint           not null, primary key
+#  impaired_streams_303d           :integer
+#  npdes_permits                   :integer
+#  num_facilities                  :integer
+#  open_underground_storage_tanks  :integer
+#  permit_effluent_violations      :integer
+#  pwsid                           :string           not null
+#  risk_management_plan_facilities :integer
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#
+# Indexes
+#
+#  index_watershed_hazards_on_pwsid  (pwsid) UNIQUE
+#
 class WatershedHazard < ApplicationRecord
   belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :watershed_hazard
 

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -2,7 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-# Explicit RuboCop config increases performance slightly while avoiding config confusion.
-ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
-
-load Gem.bin_path("rubocop", "rubocop")
+load Gem.bin_path("standard", "standardrb")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
-    config.public_file_server.headers = { "cache-control" => "public, max-age=#{2.days.to_i}" }
+    config.public_file_server.headers = {"cache-control" => "public, max-age=#{2.days.to_i}"}
   else
     config.action_controller.perform_caching = false
   end
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = {host: "localhost", port: 3000}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  config.public_file_server.headers = {"cache-control" => "public, max-age=#{1.year.to_i}"}
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -34,8 +34,8 @@ Rails.application.configure do
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  config.log_tags = [:request_id]
+  config.logger = ActiveSupport::TaggedLogging.logger($stdout)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!).
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
@@ -51,14 +51,14 @@ Rails.application.configure do
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.solid_queue.connects_to = {database: {writing: :queue}}
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = {host: "example.com"}
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -77,7 +77,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with cache-control for performance.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }
+  config.public_file_server.headers = {"cache-control" => "public, max-age=3600"}
 
   # Show full error reports.
   config.consider_all_requests_local = true
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = {host: "example.com"}
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
+  get "up" => "rails/health#show", :as => :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/db/migrate/20260413163551_create_service_area_geometries.rb
+++ b/db/migrate/20260413163551_create_service_area_geometries.rb
@@ -2,8 +2,8 @@ class CreateServiceAreaGeometries < ActiveRecord::Migration[8.1]
   def change
     create_table :service_area_geometries do |t|
       t.string :pwsid, null: false
-      t.column :geom, :geometry, geographic: false, srid: 4326, limit: { type: :multi_polygon }
-      t.column :centroid, :geometry, geographic: false, srid: 4326, limit: { type: :point }
+      t.column :geom, :geometry, geographic: false, srid: 4326, limit: {type: :multi_polygon}
+      t.column :centroid, :geometry, geographic: false, srid: 4326, limit: {type: :point}
 
       t.timestamps
     end

--- a/db/migrate/20260413163602_create_cartographic_states.rb
+++ b/db/migrate/20260413163602_create_cartographic_states.rb
@@ -6,7 +6,7 @@ class CreateCartographicStates < ActiveRecord::Migration[8.1]
       t.string :stusps, limit: 2
       t.string :name
       t.string :geoid, limit: 2
-      t.column :geom, :geometry, geographic: false, srid: 4326, limit: { type: :multi_polygon }
+      t.column :geom, :geometry, geographic: false, srid: 4326, limit: {type: :multi_polygon}
     end
 
     execute "ALTER TABLE cartographic_states ADD PRIMARY KEY (gid)"

--- a/db/migrate/20260413163603_create_cartographic_counties.rb
+++ b/db/migrate/20260413163603_create_cartographic_counties.rb
@@ -8,7 +8,7 @@ class CreateCartographicCounties < ActiveRecord::Migration[8.1]
       t.string :name
       t.string :namelsad
       t.string :stusps, limit: 2
-      t.column :geom, :geometry, geographic: false, srid: 4326, limit: { type: :multi_polygon }
+      t.column :geom, :geometry, geographic: false, srid: 4326, limit: {type: :multi_polygon}
     end
 
     execute "ALTER TABLE cartographic_counties ADD PRIMARY KEY (gid)"

--- a/db/migrate/20260413163604_create_cartographic_places.rb
+++ b/db/migrate/20260413163604_create_cartographic_places.rb
@@ -9,7 +9,7 @@ class CreateCartographicPlaces < ActiveRecord::Migration[8.1]
       t.string :namelsad
       t.string :stusps, limit: 2
       t.string :affgeoid
-      t.column :geom, :geometry, geographic: false, srid: 4326, limit: { type: :multi_polygon }
+      t.column :geom, :geometry, geographic: false, srid: 4326, limit: {type: :multi_polygon}
     end
 
     execute "ALTER TABLE cartographic_places ADD PRIMARY KEY (gid)"

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -6,24 +6,24 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key", null: false
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
-    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
-    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
-    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
   create_table "solid_queue_jobs", force: :cascade do |t|
@@ -37,17 +37,17 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "concurrency_key"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
-    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
-    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
-    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
-    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
   create_table "solid_queue_pauses", force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
-    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
   create_table "solid_queue_processes", force: :cascade do |t|
@@ -59,9 +59,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.text "metadata"
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
-    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
-    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
@@ -69,9 +69,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
-    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
-    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
@@ -79,8 +79,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.string "task_key", null: false
     t.datetime "run_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
-    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
   end
 
   create_table "solid_queue_recurring_tasks", force: :cascade do |t|
@@ -95,8 +95,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
-    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
@@ -105,8 +105,8 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
     t.datetime "created_at", null: false
-    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
-    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
   create_table "solid_queue_semaphores", force: :cascade do |t|
@@ -115,9 +115,9 @@ ActiveRecord::Schema[7.1].define(version: 1) do
     t.datetime "expires_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
-    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
-    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,86 @@
+# Glossary
+
+Domain acronyms, data source names, field abbreviations, and technical terms used in this codebase. Cross-references point to the schema tables or models where terms appear.
+
+---
+
+## Acronyms & Field Abbreviations
+
+| Term | Definition |
+|------|-----------|
+| **AIAN** | American Indian / Alaska Native — racial category in ACS data; see `demographics.aian_rate` |
+| **BWN** | Boil Water Notice — advisory issued when tap water may be unsafe without boiling; see `boil_water_summaries` |
+| **CEJST** | Climate and Economic Justice Screening Tool — White House tool identifying disadvantaged communities; see `environmental_justices.cejst_*` |
+| **CVI** | Community Vulnerability Index — composite score covering redlining, life expectancy, and cancer risk; see `environmental_justices.cvi_*` |
+| **EJScreen** | EPA Environmental Justice Screening and Mapping Tool — provides disability and drinking water non-compliance scores; see `environmental_justices.ejscreen_*` |
+| **EWG** | Environmental Working Group — publishes public water quality reports; see `public_water_systems.ewg_report_link` |
+| **FIPS** | Federal Information Processing Standards — numeric codes for U.S. states and counties; see `cartographic_counties.statefp`, `countyfp`, `geoid` |
+| **GEOID** | Census geographic identifier — concatenated FIPS codes that uniquely identify a geographic unit. County GEOID = `statefp` (2) + `countyfp` (3). Place GEOID = `statefp` (2) + `placefp` (5). See `place_system_crosswalks.geoid` |
+| **GID** | Geographic ID — auto-assigned integer primary key on cartographic tables (`cartographic_states`, `cartographic_counties`, `cartographic_places`) in place of the default `id` column |
+| **GW** | Groundwater — water sourced from underground aquifers; one of the two values for `gw_sw_code` |
+| **HUC12** | Hydrologic Unit Code (12-digit) — watershed boundary identifier used in source water protection analysis; referenced in ETL pipeline |
+| **MHI** | Median Household Income; see `demographics.median_household_income` and `trend_data.mhi_pct_change` |
+| **MVT** | Mapbox Vector Tile — protobuf binary tile format; stored in `tile_cache.mvt` and served by the vector tile endpoints |
+| **NAPI** | Native Hawaiian / Pacific Islander — racial category in ACS data; see `demographics.napi_rate` |
+| **NPDES** | National Pollutant Discharge Elimination System — EPA permit program for facilities that discharge pollutants into waterways; see `watershed_hazards.npdes_permits` |
+| **POC** | People of Color — all non-white population; see `demographics.poc_rate` and `trend_data.poc_pct_change` |
+| **pop\_cat\_5** | Population category (five tiers) — EPA classification bucketing systems by population served: Very Small (<500), Small (500–3,300), Medium (3,301–10,000), Large (10,001–100,000), Very Large (>100,000); see `public_water_systems.pop_cat_5` |
+| **PWS** | Public Water System — any system providing piped water for human consumption to 15 or more connections or 25 or more people; the core entity of this application |
+| **PWSID** | Public Water System Identifier — 9-character EPA string ID uniquely identifying each PWS. Format: 2-letter state USPS code + 7 digits (e.g., `VT0100013`). Primary key throughout the schema |
+| **RMP** | Risk Management Plan — EPA-required plan for facilities storing hazardous chemicals; see `watershed_hazards.risk_management_plan_facilities` |
+| **SABS** | Service Area Boundaries — EPA polygon dataset delimiting each PWS's geographic service area; source table `epa_sabs` in ETL, maps to `service_area_geometries` |
+| **SDWIS** | Safe Drinking Water Information System — EPA database of public water system attributes and violation records; primary ETL data source |
+| **SRF** | State Revolving Fund — EPA/state low-interest loan program for drinking water infrastructure improvements; see `funding_summaries.total_srf_assistance` |
+| **SRID** | Spatial Reference Identifier — numeric code identifying a coordinate reference system. 4326 = WGS 84 (lat/lng), 3857 = Web Mercator (tiles) |
+| **STUSPS** | State USPS Abbreviation — 2-letter postal code (e.g., `VT`, `RI`); used as the state component of PWSID and as a filter/index field |
+| **SVI** | Social Vulnerability Index — CDC composite index measuring community vulnerability to hazards; see `environmental_justices.svi_overall_pctl` |
+| **SW** | Surface Water — water sourced from rivers, lakes, or reservoirs; one of the two values for `gw_sw_code` |
+| **UST** | Underground Storage Tank — tracked by EPA for contamination risk; see `watershed_hazards.open_underground_storage_tanks` |
+| **xwalk** | Crosswalk — a mapping table joining two datasets by a shared key. `place_system_crosswalks` maps Census places to PWS service areas with overlap fractions |
+
+---
+
+## Data Sources
+
+| Source | Description |
+|--------|-----------|
+| **ACS** | American Community Survey — U.S. Census Bureau periodic demographic survey; source for `demographics` and `trend_data` |
+| **CEJST** | Climate and Economic Justice Screening Tool — White House Council on Environmental Quality; source for `environmental_justices.cejst_*` fields |
+| **CVI** | Community Vulnerability Index — composite index from redlining, life expectancy, and cancer risk data; source for `environmental_justices.cvi_*` fields |
+| **EPA EJScreen** | EPA Environmental Justice Screening Tool — provides disability and drinking water compliance scores; source for `environmental_justices.ejscreen_*` fields |
+| **EPA SABS** | EPA Service Area Boundaries — GeoJSON polygon dataset for map rendering; ETL source table `epa_sabs`, stored in `service_area_geometries` |
+| **EPA SDWIS** | Safe Drinking Water Information System — authoritative source for PWS attributes, violations, and boil water data; primary ETL input |
+| **SRF** | State Revolving Fund loan database — source for `funding_summaries` |
+| **CDC SVI** | CDC Social Vulnerability Index — census-tract composite scores; source for `environmental_justices.svi_overall_pctl` |
+
+---
+
+## Water System Classification Codes
+
+| Field | Values & Meaning |
+|-------|----------------|
+| `gw_sw_code` | `"Groundwater"` / `"Surface Water"` — primary water source type |
+| `owner_type` | `"Federal"`, `"State"`, `"Local Government"`, `"Native American"`, `"Private"`, `"Public/Private"` |
+| `pop_cat_5` | `"Very Small"` (<500), `"Small"` (500–3,300), `"Medium"` (3,301–10,000), `"Large"` (10,001–100,000), `"Very Large"` (>100,000) |
+| `primary_source_code` | EPA code for detailed water source type (e.g., `GW` = groundwater, `SW` = surface water, `GU` = groundwater under direct influence of surface water) |
+| `primacy_type` | `"State"`, `"Tribal"`, `"Territory"` — type of regulatory authority overseeing the system |
+| `primacy_agency` | Name of the state/tribal/territory agency with regulatory authority (SDWIS primacy) |
+| `service_area_type` | `"System Sourced"` (boundary provided by the PWS) or `"Modeled"` (boundary estimated from census data) |
+| `source_water_protection_code` | EPA indicator for whether the system has an active source water protection program |
+| `open_health_viol` | `"Yes"` / `"No"` — whether the system currently has an open health-based violation |
+| `symbology_field` | Derived field used to drive Mapbox layer styling and legend classification |
+
+---
+
+## Technical Terms
+
+| Term | Definition |
+|------|-----------|
+| **GiST Index** | Generalized Search Tree — PostgreSQL index type used on geometry columns (`geom`, `centroid`) to enable fast spatial queries |
+| **MVT** | See Mapbox Vector Tile above |
+| **PostGIS** | PostgreSQL extension providing geometry data types (`multi_polygon`, `st_point`) and spatial functions (`ST_Transform`, `ST_PointOnSurface`, `ST_Buffer`) |
+| **ST_Transform** | PostGIS function converting geometries between coordinate systems; used to reproject from EPSG:4326 (stored) to EPSG:3857 (tile rendering) |
+| **Tile Cache** | `tile_cache` table — stores MVT protobuf binaries keyed by `(layer, z, x, y)`. Invalidated after ETL runs. Five layers: `pws`, `pws_points`, `places`, `counties`, `states` |
+| **TileBBox** | PostGIS utility function converting tile coordinates `(z, x, y)` to a bounding box geometry for use in MVT generation queries |
+| **WGS 84** | World Geodetic System 1984 — coordinate reference system (EPSG:4326) used to store all geometries in this database |
+| **Web Mercator** | EPSG:3857 — projected coordinate system used by Mapbox GL JS for tile rendering; geometries are reprojected to this system at tile generation time |

--- a/lib/tasks/annotate.rake
+++ b/lib/tasks/annotate.rake
@@ -1,0 +1,5 @@
+return unless Rails.env.development?
+
+Rake::Task.define_task("db:migrate": :environment) do
+  AnnotateRb::ModelAnnotator::Annotator.do_annotations(models: true)
+end

--- a/lib/tasks/seed_states.rake
+++ b/lib/tasks/seed_states.rake
@@ -4,32 +4,32 @@ require "csv"
 module SeedImport
   module_function
 
-  def SeedImport.each_row(dir, filename, states, &block)
+  def self.each_row(dir, filename, states, &block)
     CSV.foreach(dir.join(filename), headers: true) do |row|
       block.call(row) if states.any? { |s| row["pwsid"]&.start_with?(s) }
     end
   end
 
-  def SeedImport.cast_int(val)
+  def self.cast_int(val)
     return nil if val.nil? || val.strip == "" || val.strip.upcase == "NA"
 
     val.strip.to_i
   end
 
-  def SeedImport.cast_dec(val)
+  def self.cast_dec(val)
     return nil if val.nil? || val.strip == "" || val.strip.upcase == "NA"
 
     val.strip.to_d
   end
 
-  def SeedImport.cast_bool(val)
+  def self.cast_bool(val)
     return nil if val.nil? || val.strip == ""
 
     val.strip.upcase == "Y"
   end
 
   # Source scores are stored as 0–1 floats; multiply by 100 at import time.
-  def SeedImport.cast_score(val)
+  def self.cast_score(val)
     return nil if val.nil? || val.strip == "" || val.strip.upcase == "NA"
 
     (val.strip.to_f * 100).round(2)
@@ -39,13 +39,13 @@ end
 namespace :db do
   namespace :seed do
     desc "Seed database with water system data for given states: bin/rails db:seed:states[VT,RI]"
-    task :states, [ :states ] => :environment do |_, args|
+    task :states, [:states] => :environment do |_, args|
       abort "Usage: bin/rails db:seed:states[VT,RI]" if args[:states].blank?
 
-      states = ([ args[:states] ] + args.extras).compact.map(&:strip).map(&:upcase)
+      states = ([args[:states]] + args.extras).compact.map(&:strip).map(&:upcase)
       dir = Rails.root.join("db/seeds/csv")
 
-      puts "→ Seeding #{states.join(', ')}..."
+      puts "→ Seeding #{states.join(", ")}..."
 
       # Collect the pwsids we care about upfront — used to filter all subsequent files
       target_pwsids = Set.new
@@ -57,20 +57,20 @@ namespace :db do
       SeedImport.each_row(dir, "epa_sabs.csv", states) do |row|
         target_pwsids << row["pwsid"]
         pws_rows << {
-          pwsid:                    row["pwsid"],
-          pws_name:                 row["pws_name"],
-          stusps:                   row["pwsid"][0, 2],
-          primacy_agency:           row["primacy_agency"],
-          pop_cat_5:                row["pop_cat_5"],
-          population_served_count:  SeedImport.cast_int(row["population_served_count"]),
+          pwsid: row["pwsid"],
+          pws_name: row["pws_name"],
+          stusps: row["pwsid"][0, 2],
+          primacy_agency: row["primacy_agency"],
+          pop_cat_5: row["pop_cat_5"],
+          population_served_count: SeedImport.cast_int(row["population_served_count"]),
           service_connections_count: SeedImport.cast_int(row["service_connections_count"]),
-          service_area_type:        row["service_area_type"],
-          symbology_field:          row["symbology_field"],
+          service_area_type: row["service_area_type"],
+          symbology_field: row["symbology_field"],
           detailed_facility_report: row["detailed_facility_report"],
-          ewg_report_link:          row["ewg_report_link"],
-          area_sq_miles:            SeedImport.cast_dec(row["epic_area_mi2"]),
-          created_at:               Time.current,
-          updated_at:               Time.current
+          ewg_report_link: row["ewg_report_link"],
+          area_sq_miles: SeedImport.cast_dec(row["epic_area_mi2"]),
+          created_at: Time.current,
+          updated_at: Time.current
         }
       end
 
@@ -87,53 +87,53 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
 
         pws_updates << {
-          pwsid:                       row["pwsid"],
-          gw_sw_code:                  row["gw_sw_code"],
-          primary_source_code:         row["primary_source_code"],
-          first_reported_date:         row["first_reported_date"],
-          years_operating:             SeedImport.cast_int(row["years_operating"]),
-          owner_type:                  row["owner_type"],
-          primacy_type:                row["primacy_type"],
-          is_grant_eligible:           SeedImport.cast_bool(row["is_grant_eligible_ind"]),
-          is_wholesaler:               SeedImport.cast_bool(row["is_wholesaler_ind"]),
-          is_school_or_daycare:        SeedImport.cast_bool(row["is_school_or_daycare_ind"]),
+          pwsid: row["pwsid"],
+          gw_sw_code: row["gw_sw_code"],
+          primary_source_code: row["primary_source_code"],
+          first_reported_date: row["first_reported_date"],
+          years_operating: SeedImport.cast_int(row["years_operating"]),
+          owner_type: row["owner_type"],
+          primacy_type: row["primacy_type"],
+          is_grant_eligible: SeedImport.cast_bool(row["is_grant_eligible_ind"]),
+          is_wholesaler: SeedImport.cast_bool(row["is_wholesaler_ind"]),
+          is_school_or_daycare: SeedImport.cast_bool(row["is_school_or_daycare_ind"]),
           source_water_protection_code: row["source_water_protection_code"],
-          phone_number:                row["phone_number"],
-          open_health_viol:            row["open_health_viol"],
-          updated_at:                  Time.current
+          phone_number: row["phone_number"],
+          open_health_viol: row["open_health_viol"],
+          updated_at: Time.current
         }
 
         viol_rows << {
-          pwsid:                             row["pwsid"],
-          lead_and_copper_5yr:               SeedImport.cast_int(row["lead_and_copper_rule_healthbased_5yr"]),
-          radionuclides_5yr:                 SeedImport.cast_int(row["radionuclides_and_revised_rad_rule_healthbased_5yr"]),
-          groundwater_rule_5yr:              SeedImport.cast_int(row["groundwater_rule_healthbased_5yr"]),
-          surface_water_treatment_5yr:       SeedImport.cast_int(row["surface_water_treatment_rules_healthbased_5yr"]),
-          total_coliform_5yr:                SeedImport.cast_int(row["total_coliform_rules_healthbased_5yr"]),
-          inorganic_chemicals_5yr:           SeedImport.cast_int(row["inorganic_chemicals_healthbased_5yr"]),
-          stage_1_disinfectants_5yr:         SeedImport.cast_int(row["stage_1_disinfectants_and_byproducts_rule_healthbased_5yr"]),
-          stage_2_disinfectants_5yr:         SeedImport.cast_int(row["stage_2_disinfectants_and_byproducts_rule_healthbased_5yr"]),
-          synthetic_organic_chemicals_5yr:   SeedImport.cast_int(row["synthetic_organic_chemicals_healthbased_5yr"]),
-          volatile_organic_chemicals_5yr:    SeedImport.cast_int(row["volatile_organic_chemicals_healthbased_5yr"]),
-          health_violations_5yr:             SeedImport.cast_int(row["health_viols_5yr"]),
-          paperwork_violations_5yr:          SeedImport.cast_int(row["paperwork_viols_5yr"]),
-          total_violations_5yr:              SeedImport.cast_int(row["total_viols_5yr"]),
-          lead_and_copper_10yr:              SeedImport.cast_int(row["lead_and_copper_rule_healthbased_10yr"]),
-          radionuclides_10yr:                SeedImport.cast_int(row["radionuclides_and_revised_rad_rule_healthbased_10yr"]),
-          groundwater_rule_10yr:             SeedImport.cast_int(row["groundwater_rule_healthbased_10yr"]),
-          surface_water_treatment_10yr:      SeedImport.cast_int(row["surface_water_treatment_rules_healthbased_10yr"]),
-          total_coliform_10yr:               SeedImport.cast_int(row["total_coliform_rules_healthbased_10yr"]),
-          inorganic_chemicals_10yr:          SeedImport.cast_int(row["inorganic_chemicals_healthbased_10yr"]),
-          stage_1_disinfectants_10yr:        SeedImport.cast_int(row["stage_1_disinfectants_and_byproducts_rule_healthbased_10yr"]),
-          stage_2_disinfectants_10yr:        SeedImport.cast_int(row["stage_2_disinfectants_and_byproducts_rule_healthbased_10yr"]),
-          synthetic_organic_chemicals_10yr:  SeedImport.cast_int(row["synthetic_organic_chemicals_healthbased_10yr"]),
-          volatile_organic_chemicals_10yr:   SeedImport.cast_int(row["volatile_organic_chemicals_healthbased_10yr"]),
-          health_violations_10yr:            SeedImport.cast_int(row["health_viols_10yr"]),
-          paperwork_violations_10yr:         SeedImport.cast_int(row["paperwork_viols_10yr"]),
-          total_violations_10yr:             SeedImport.cast_int(row["total_viols_10yr"]),
-          violations_all_years:              SeedImport.cast_int(row["violations_all_years"]),
-          created_at:                        Time.current,
-          updated_at:                        Time.current
+          pwsid: row["pwsid"],
+          lead_and_copper_5yr: SeedImport.cast_int(row["lead_and_copper_rule_healthbased_5yr"]),
+          radionuclides_5yr: SeedImport.cast_int(row["radionuclides_and_revised_rad_rule_healthbased_5yr"]),
+          groundwater_rule_5yr: SeedImport.cast_int(row["groundwater_rule_healthbased_5yr"]),
+          surface_water_treatment_5yr: SeedImport.cast_int(row["surface_water_treatment_rules_healthbased_5yr"]),
+          total_coliform_5yr: SeedImport.cast_int(row["total_coliform_rules_healthbased_5yr"]),
+          inorganic_chemicals_5yr: SeedImport.cast_int(row["inorganic_chemicals_healthbased_5yr"]),
+          stage_1_disinfectants_5yr: SeedImport.cast_int(row["stage_1_disinfectants_and_byproducts_rule_healthbased_5yr"]),
+          stage_2_disinfectants_5yr: SeedImport.cast_int(row["stage_2_disinfectants_and_byproducts_rule_healthbased_5yr"]),
+          synthetic_organic_chemicals_5yr: SeedImport.cast_int(row["synthetic_organic_chemicals_healthbased_5yr"]),
+          volatile_organic_chemicals_5yr: SeedImport.cast_int(row["volatile_organic_chemicals_healthbased_5yr"]),
+          health_violations_5yr: SeedImport.cast_int(row["health_viols_5yr"]),
+          paperwork_violations_5yr: SeedImport.cast_int(row["paperwork_viols_5yr"]),
+          total_violations_5yr: SeedImport.cast_int(row["total_viols_5yr"]),
+          lead_and_copper_10yr: SeedImport.cast_int(row["lead_and_copper_rule_healthbased_10yr"]),
+          radionuclides_10yr: SeedImport.cast_int(row["radionuclides_and_revised_rad_rule_healthbased_10yr"]),
+          groundwater_rule_10yr: SeedImport.cast_int(row["groundwater_rule_healthbased_10yr"]),
+          surface_water_treatment_10yr: SeedImport.cast_int(row["surface_water_treatment_rules_healthbased_10yr"]),
+          total_coliform_10yr: SeedImport.cast_int(row["total_coliform_rules_healthbased_10yr"]),
+          inorganic_chemicals_10yr: SeedImport.cast_int(row["inorganic_chemicals_healthbased_10yr"]),
+          stage_1_disinfectants_10yr: SeedImport.cast_int(row["stage_1_disinfectants_and_byproducts_rule_healthbased_10yr"]),
+          stage_2_disinfectants_10yr: SeedImport.cast_int(row["stage_2_disinfectants_and_byproducts_rule_healthbased_10yr"]),
+          synthetic_organic_chemicals_10yr: SeedImport.cast_int(row["synthetic_organic_chemicals_healthbased_10yr"]),
+          volatile_organic_chemicals_10yr: SeedImport.cast_int(row["volatile_organic_chemicals_healthbased_10yr"]),
+          health_violations_10yr: SeedImport.cast_int(row["health_viols_10yr"]),
+          paperwork_violations_10yr: SeedImport.cast_int(row["paperwork_viols_10yr"]),
+          total_violations_10yr: SeedImport.cast_int(row["total_viols_10yr"]),
+          violations_all_years: SeedImport.cast_int(row["violations_all_years"]),
+          created_at: Time.current,
+          updated_at: Time.current
         }
       end
 
@@ -149,38 +149,38 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
 
         demo_rows << {
-          pwsid:                          row["pwsid"],
-          total_population:               SeedImport.cast_int(row["total_pop"]),
-          population_density:             SeedImport.cast_dec(row["epic_pop_density"]),
-          median_household_income:        SeedImport.cast_int(row["mhi"]),
+          pwsid: row["pwsid"],
+          total_population: SeedImport.cast_int(row["total_pop"]),
+          population_density: SeedImport.cast_dec(row["epic_pop_density"]),
+          median_household_income: SeedImport.cast_int(row["mhi"]),
           household_income_lowest_quintile: SeedImport.cast_int(row["hh_inc_lowest_quintile"]),
-          poverty_rate:                   SeedImport.cast_dec(row["hh_below_pov_per"]),
-          population_in_poverty_rate:     SeedImport.cast_dec(row["pop_in_pov_per"]),
-          unemployment_rate:              SeedImport.cast_dec(row["laborforce_unemployed_per"]),
-          bachelors_degree_rate:          SeedImport.cast_dec(row["bachelors_per"]),
-          no_health_insurance_rate:       SeedImport.cast_dec(row["no_health_insurance_per"]),
-          age_under_5_rate:               SeedImport.cast_dec(row["ageunder_5_per"]),
-          age_over_61_rate:               SeedImport.cast_dec(row["age_over_61_per"]),
-          white_rate:                     SeedImport.cast_dec(row["white_alone_per"]),
-          black_rate:                     SeedImport.cast_dec(row["black_alone_per"]),
-          asian_rate:                     SeedImport.cast_dec(row["asian_alone_per"]),
-          aian_rate:                      SeedImport.cast_dec(row["AIAN_alone_per"]),
-          napi_rate:                      SeedImport.cast_dec(row["NAPI_alone_per"]),
-          hispanic_rate:                  SeedImport.cast_dec(row["hisp_alone_per"]),
-          other_race_rate:                SeedImport.cast_dec(row["other_alone_per"]),
-          mixed_race_rate:                SeedImport.cast_dec(row["mixed_alone_per"]),
-          poc_rate:                       SeedImport.cast_dec(row["poc_alone_per"]),
-          renter_rate:                    SeedImport.cast_dec(row["hh_rent_home_per"]),
-          owner_rate:                     SeedImport.cast_dec(row["hh_own_home_per"]),
-          water_rate_under_125:           SeedImport.cast_dec(row["water_rate_less_125_per"]),
-          water_rate_125_249:             SeedImport.cast_dec(row["water_rate_between_125_249_per"]),
-          water_rate_250_499:             SeedImport.cast_dec(row["water_rate_between_250_499_per"]),
-          water_rate_500_749:             SeedImport.cast_dec(row["water_rate_between_500_749_per"]),
-          water_rate_750_999:             SeedImport.cast_dec(row["water_rate_between_750_999_per"]),
-          water_rate_over_1000:           SeedImport.cast_dec(row["water_rate_over_1000_per"]),
-          most_common_rate_tier:          row["most_common_rate_tidy"], # CSV column is "most_common_rate_tidy" (source typo)
-          created_at:                     Time.current,
-          updated_at:                     Time.current
+          poverty_rate: SeedImport.cast_dec(row["hh_below_pov_per"]),
+          population_in_poverty_rate: SeedImport.cast_dec(row["pop_in_pov_per"]),
+          unemployment_rate: SeedImport.cast_dec(row["laborforce_unemployed_per"]),
+          bachelors_degree_rate: SeedImport.cast_dec(row["bachelors_per"]),
+          no_health_insurance_rate: SeedImport.cast_dec(row["no_health_insurance_per"]),
+          age_under_5_rate: SeedImport.cast_dec(row["ageunder_5_per"]),
+          age_over_61_rate: SeedImport.cast_dec(row["age_over_61_per"]),
+          white_rate: SeedImport.cast_dec(row["white_alone_per"]),
+          black_rate: SeedImport.cast_dec(row["black_alone_per"]),
+          asian_rate: SeedImport.cast_dec(row["asian_alone_per"]),
+          aian_rate: SeedImport.cast_dec(row["AIAN_alone_per"]),
+          napi_rate: SeedImport.cast_dec(row["NAPI_alone_per"]),
+          hispanic_rate: SeedImport.cast_dec(row["hisp_alone_per"]),
+          other_race_rate: SeedImport.cast_dec(row["other_alone_per"]),
+          mixed_race_rate: SeedImport.cast_dec(row["mixed_alone_per"]),
+          poc_rate: SeedImport.cast_dec(row["poc_alone_per"]),
+          renter_rate: SeedImport.cast_dec(row["hh_rent_home_per"]),
+          owner_rate: SeedImport.cast_dec(row["hh_own_home_per"]),
+          water_rate_under_125: SeedImport.cast_dec(row["water_rate_less_125_per"]),
+          water_rate_125_249: SeedImport.cast_dec(row["water_rate_between_125_249_per"]),
+          water_rate_250_499: SeedImport.cast_dec(row["water_rate_between_250_499_per"]),
+          water_rate_500_749: SeedImport.cast_dec(row["water_rate_between_500_749_per"]),
+          water_rate_750_999: SeedImport.cast_dec(row["water_rate_between_750_999_per"]),
+          water_rate_over_1000: SeedImport.cast_dec(row["water_rate_over_1000_per"]),
+          most_common_rate_tier: row["most_common_rate_tidy"], # CSV column is "most_common_rate_tidy" (source typo)
+          created_at: Time.current,
+          updated_at: Time.current
         }
       end
 
@@ -195,21 +195,21 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
 
         trend_rows << {
-          pwsid:                            row["pwsid"],
-          population_pct_change:            SeedImport.cast_dec(row["total_pop_pct_change_2011_2021"]),
-          unemployment_pct_change:          SeedImport.cast_dec(row["laborforce_unemployed_pct_change_2011_2021"]),
-          mhi_pct_change:                   SeedImport.cast_dec(row["mhi_pct_change_2011_2021"]),
-          lowest_quintile_pct_change:       SeedImport.cast_dec(row["hh_inc_lowest_quintile_pct_change_2011_2021"]),
-          households_pct_change:            SeedImport.cast_dec(row["hh_total_pct_change_2011_2021"]),
-          poverty_pct_change:               SeedImport.cast_dec(row["hh_below_pov_pct_change_2011_2021"]),
-          poc_pct_change:                   SeedImport.cast_dec(row["poc_alone_per_pct_change_2011_2021"]),
+          pwsid: row["pwsid"],
+          population_pct_change: SeedImport.cast_dec(row["total_pop_pct_change_2011_2021"]),
+          unemployment_pct_change: SeedImport.cast_dec(row["laborforce_unemployed_pct_change_2011_2021"]),
+          mhi_pct_change: SeedImport.cast_dec(row["mhi_pct_change_2011_2021"]),
+          lowest_quintile_pct_change: SeedImport.cast_dec(row["hh_inc_lowest_quintile_pct_change_2011_2021"]),
+          households_pct_change: SeedImport.cast_dec(row["hh_total_pct_change_2011_2021"]),
+          poverty_pct_change: SeedImport.cast_dec(row["hh_below_pov_pct_change_2011_2021"]),
+          poc_pct_change: SeedImport.cast_dec(row["poc_alone_per_pct_change_2011_2021"]),
           population_in_poverty_pct_change: SeedImport.cast_dec(row["pop_in_pov_per_pct_change_2011_2021"]),
-          income_change_flag:               row["income_change_flag"],
-          population_change_flag:           row["population_change_flag"],
-          population_pct_change_capped:     SeedImport.cast_dec(row["total_pop_pct_change_2011_2021_cap"]),
-          mhi_pct_change_capped:            SeedImport.cast_dec(row["mhi_pct_change_2011_2021_cap"]),
-          created_at:                       Time.current,
-          updated_at:                       Time.current
+          income_change_flag: row["income_change_flag"],
+          population_change_flag: row["population_change_flag"],
+          population_pct_change_capped: SeedImport.cast_dec(row["total_pop_pct_change_2011_2021_cap"]),
+          mhi_pct_change_capped: SeedImport.cast_dec(row["mhi_pct_change_2011_2021_cap"]),
+          created_at: Time.current,
+          updated_at: Time.current
         }
       end
 
@@ -219,14 +219,14 @@ namespace :db do
       # ---------------------------------------------------------------------------
       # 5. EnvironmentalJustice — merge 4 files into one table
       # ---------------------------------------------------------------------------
-      ej = Hash.new { |h, k| h[k] = { pwsid: k, created_at: Time.current, updated_at: Time.current } }
+      ej = Hash.new { |h, k| h[k] = {pwsid: k, created_at: Time.current, updated_at: Time.current} }
 
       SeedImport.each_row(dir, "cejst.csv", states) do |row|
         next unless target_pwsids.include?(row["pwsid"])
         ej[row["pwsid"]].merge!(
-          cejst_disadvantaged_pct:        SeedImport.cast_score(row["a_int.identified_as_disadvantaged"]),
-          cejst_lead_paint_indicator:     SeedImport.cast_int(row["pw_int_hh.percent_pre_1960s_housing_lead_paint_indicator"]),
-          cejst_low_life_expectancy_pctl: SeedImport.cast_dec(row["pw_int_pop.low_life_expectancy_percentile"]),
+          cejst_disadvantaged_pct: SeedImport.cast_score(row["a_int.identified_as_disadvantaged"]),
+          cejst_lead_paint_indicator: SeedImport.cast_int(row["pw_int_hh.percent_pre_1960s_housing_lead_paint_indicator"]),
+          cejst_low_life_expectancy_pctl: SeedImport.cast_dec(row["pw_int_pop.low_life_expectancy_percentile"])
         )
       end
 
@@ -234,24 +234,24 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
         ej[row["pwsid"]].merge!(
           ejscreen_drinking_water: SeedImport.cast_dec(row["a_int.dwater"]),
-          ejscreen_disability_rate: SeedImport.cast_dec(row["pw_ext_pop.disability"]),
+          ejscreen_disability_rate: SeedImport.cast_dec(row["pw_ext_pop.disability"])
         )
       end
 
       SeedImport.each_row(dir, "svi.csv", states) do |row|
         next unless target_pwsids.include?(row["pwsid"])
         ej[row["pwsid"]].merge!(
-          svi_overall_pctl: SeedImport.cast_score(row["pw_int_pop.rpl_themes"]),
+          svi_overall_pctl: SeedImport.cast_score(row["pw_int_pop.rpl_themes"])
         )
       end
 
       SeedImport.each_row(dir, "cvi.csv", states) do |row|
         next unless target_pwsids.include?(row["pwsid"])
         ej[row["pwsid"]].merge!(
-          cvi_redlining:    SeedImport.cast_dec(row["pw_int_hh.redlining"]),
+          cvi_redlining: SeedImport.cast_dec(row["pw_int_hh.redlining"]),
           cvi_life_expectancy: SeedImport.cast_dec(row["pw_int_pop.life_expectancy"]),
-          cvi_cancer_risk:  SeedImport.cast_dec(row["pw_int_pop.cancer"]),
-          cvi_overall_score: SeedImport.cast_score(row["a_int.overall_cvi_score"]),
+          cvi_cancer_risk: SeedImport.cast_dec(row["pw_int_pop.cancer"]),
+          cvi_overall_score: SeedImport.cast_score(row["a_int.overall_cvi_score"])
         )
       end
 
@@ -267,18 +267,18 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
 
         bwn_rows << {
-          pwsid:                    row["pwsid"],
-          first_advisory_date:      row["date_of_first_advisory"],
-          last_advisory_date:       row["date_of_last_advisory"],
-          total_notices:            SeedImport.cast_int(row["total_bwn"]),
+          pwsid: row["pwsid"],
+          first_advisory_date: row["date_of_first_advisory"],
+          last_advisory_date: row["date_of_last_advisory"],
+          total_notices: SeedImport.cast_int(row["total_bwn"]),
           state_reporting_year_min: row["min_reporting_year_for_state"],
           state_reporting_year_max: row["max_reporting_year_for_state"],
-          state:                    row["state"],
-          tooltip_text:             row["data_tool_tip"],
-          download_url:             row["download_link"],
-          date_range_display:       row["clean_date_range"],
-          created_at:               Time.current,
-          updated_at:               Time.current
+          state: row["state"],
+          tooltip_text: row["data_tool_tip"],
+          download_url: row["download_link"],
+          date_range_display: row["clean_date_range"],
+          created_at: Time.current,
+          updated_at: Time.current
         }
       end
 
@@ -293,13 +293,13 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
 
         funding_rows << {
-          pwsid:                      row["pwsid"],
-          times_funded:               SeedImport.cast_int(row["times_funded"]),
-          total_srf_assistance:       SeedImport.cast_dec(row["total_srf_assistance"]),
-          median_srf_assistance:      SeedImport.cast_dec(row["median_srf_assistance"]),
+          pwsid: row["pwsid"],
+          times_funded: SeedImport.cast_int(row["times_funded"]),
+          total_srf_assistance: SeedImport.cast_dec(row["total_srf_assistance"]),
+          median_srf_assistance: SeedImport.cast_dec(row["median_srf_assistance"]),
           total_principal_forgiveness: SeedImport.cast_dec(row["total_principal_forgiveness"]),
-          created_at:                 Time.current,
-          updated_at:                 Time.current
+          created_at: Time.current,
+          updated_at: Time.current
         }
       end
 
@@ -314,16 +314,16 @@ namespace :db do
         next unless target_pwsids.include?(row["pwsid"])
 
         pwsid = row["pwsid"]
-        hazard_agg[pwsid] ||= { pwsid: pwsid, num_facilities: 0, npdes_permits: 0,
-                                 permit_effluent_violations: 0, open_underground_storage_tanks: 0,
-                                 risk_management_plan_facilities: 0, impaired_streams_303d: 0,
-                                 created_at: Time.current, updated_at: Time.current }
-        hazard_agg[pwsid][:num_facilities]                  += SeedImport.cast_int(row["num_facilities"]).to_i
-        hazard_agg[pwsid][:npdes_permits]                   += SeedImport.cast_int(row["npdes_permits"]).to_i
-        hazard_agg[pwsid][:permit_effluent_violations]      += SeedImport.cast_int(row["total_permit_eff_viols"]).to_i
-        hazard_agg[pwsid][:open_underground_storage_tanks]  += SeedImport.cast_int(row["total_open_usts"]).to_i
+        hazard_agg[pwsid] ||= {pwsid: pwsid, num_facilities: 0, npdes_permits: 0,
+                               permit_effluent_violations: 0, open_underground_storage_tanks: 0,
+                               risk_management_plan_facilities: 0, impaired_streams_303d: 0,
+                               created_at: Time.current, updated_at: Time.current}
+        hazard_agg[pwsid][:num_facilities] += SeedImport.cast_int(row["num_facilities"]).to_i
+        hazard_agg[pwsid][:npdes_permits] += SeedImport.cast_int(row["npdes_permits"]).to_i
+        hazard_agg[pwsid][:permit_effluent_violations] += SeedImport.cast_int(row["total_permit_eff_viols"]).to_i
+        hazard_agg[pwsid][:open_underground_storage_tanks] += SeedImport.cast_int(row["total_open_usts"]).to_i
         hazard_agg[pwsid][:risk_management_plan_facilities] += SeedImport.cast_int(row["total_facilities_w_rmps"]).to_i
-        hazard_agg[pwsid][:impaired_streams_303d]           += SeedImport.cast_int(row["streams_303d_list"]).to_i
+        hazard_agg[pwsid][:impaired_streams_303d] += SeedImport.cast_int(row["streams_303d_list"]).to_i
       end
 
       hazard_rows = hazard_agg.values

--- a/spec/factories/boil_water_summaries.rb
+++ b/spec/factories/boil_water_summaries.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: boil_water_summaries
+#
+#  id                       :bigint           not null, primary key
+#  date_range_display       :string
+#  download_url             :string
+#  first_advisory_date      :string
+#  last_advisory_date       :string
+#  pwsid                    :string           not null
+#  state                    :string
+#  state_reporting_year_max :string
+#  state_reporting_year_min :string
+#  tooltip_text             :text
+#  total_notices            :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_boil_water_summaries_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :boil_water_summary do
     association :public_water_system

--- a/spec/factories/cartographic_counties.rb
+++ b/spec/factories/cartographic_counties.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: cartographic_counties
+#
+#  countyfp :string(3)
+#  geoid    :string(5)
+#  geom     :geometry         multipolygon, 4326
+#  gid      :integer          not null, primary key
+#  name     :string
+#  namelsad :string
+#  statefp  :string(2)
+#  stusps   :string(2)
+#
+# Indexes
+#
+#  index_cartographic_counties_on_geom                 (geom) USING gist
+#  index_cartographic_counties_on_namelsad_and_stusps  (namelsad,stusps)
+#
 FactoryBot.define do
   factory :cartographic_county do
     sequence(:gid) { |n| n }

--- a/spec/factories/cartographic_places.rb
+++ b/spec/factories/cartographic_places.rb
@@ -1,9 +1,29 @@
+# == Schema Information
+#
+# Table name: cartographic_places
+#
+#  affgeoid :string
+#  geoid    :string(7)
+#  geom     :geometry         multipolygon, 4326
+#  gid      :integer          not null, primary key
+#  name     :string
+#  namelsad :string
+#  placefp  :string(5)
+#  statefp  :string(2)
+#  stusps   :string(2)
+#
+# Indexes
+#
+#  index_cartographic_places_on_affgeoid  (affgeoid)
+#  index_cartographic_places_on_geoid     (geoid)
+#  index_cartographic_places_on_geom      (geom) USING gist
+#
 FactoryBot.define do
   factory :cartographic_place do
     sequence(:gid) { |n| n }
     statefp { "50" }
     placefp { "73600" }
-    sequence(:geoid) { |n| "50#{format('%05d', n)}" }
+    sequence(:geoid) { |n| "50#{format("%05d", n)}" }
     name { "Montpelier" }
     namelsad { "Montpelier city" }
     stusps { "VT" }

--- a/spec/factories/cartographic_states.rb
+++ b/spec/factories/cartographic_states.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: cartographic_states
+#
+#  geoid   :string(2)
+#  geom    :geometry         multipolygon, 4326
+#  gid     :integer          not null, primary key
+#  name    :string
+#  statefp :string(2)
+#  stusps  :string(2)
+#
+# Indexes
+#
+#  index_cartographic_states_on_geom  (geom) USING gist
+#
 FactoryBot.define do
   factory :cartographic_state do
     sequence(:gid) { |n| n }

--- a/spec/factories/data_imports.rb
+++ b/spec/factories/data_imports.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: data_imports
+#
+#  id          :bigint           not null, primary key
+#  file_url    :string           not null
+#  imported_at :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_data_imports_on_file_url  (file_url)
+#
 FactoryBot.define do
   factory :data_import do
     sequence(:file_url) { |n| "https://s3.example.com/data/file_#{n}.csv" }

--- a/spec/factories/demographics.rb
+++ b/spec/factories/demographics.rb
@@ -1,3 +1,45 @@
+# == Schema Information
+#
+# Table name: demographics
+#
+#  id                               :bigint           not null, primary key
+#  age_over_61_rate                 :decimal(5, 2)
+#  age_under_5_rate                 :decimal(5, 2)
+#  aian_rate                        :decimal(5, 2)
+#  asian_rate                       :decimal(5, 2)
+#  bachelors_degree_rate            :decimal(5, 2)
+#  black_rate                       :decimal(5, 2)
+#  hispanic_rate                    :decimal(5, 2)
+#  household_income_lowest_quintile :integer
+#  median_household_income          :integer
+#  mixed_race_rate                  :decimal(5, 2)
+#  most_common_rate_tier            :string
+#  napi_rate                        :decimal(5, 2)
+#  no_health_insurance_rate         :decimal(5, 2)
+#  other_race_rate                  :decimal(5, 2)
+#  owner_rate                       :decimal(5, 2)
+#  poc_rate                         :decimal(5, 2)
+#  population_density               :decimal(, )
+#  population_in_poverty_rate       :decimal(5, 2)
+#  poverty_rate                     :decimal(5, 2)
+#  pwsid                            :string           not null
+#  renter_rate                      :decimal(5, 2)
+#  total_population                 :integer
+#  unemployment_rate                :decimal(5, 2)
+#  water_rate_125_249               :decimal(5, 2)
+#  water_rate_250_499               :decimal(5, 2)
+#  water_rate_500_749               :decimal(5, 2)
+#  water_rate_750_999               :decimal(5, 2)
+#  water_rate_over_1000             :decimal(5, 2)
+#  water_rate_under_125             :decimal(5, 2)
+#  white_rate                       :decimal(5, 2)
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_demographics_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :demographic do
     association :public_water_system

--- a/spec/factories/environmental_justices.rb
+++ b/spec/factories/environmental_justices.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: environmental_justices
+#
+#  id                             :bigint           not null, primary key
+#  cejst_disadvantaged_pct        :decimal(5, 2)
+#  cejst_lead_paint_indicator     :integer
+#  cejst_low_life_expectancy_pctl :decimal(, )
+#  cvi_cancer_risk                :decimal(, )
+#  cvi_life_expectancy            :decimal(, )
+#  cvi_overall_score              :decimal(5, 2)
+#  cvi_redlining                  :decimal(, )
+#  ejscreen_disability_rate       :decimal(, )
+#  ejscreen_drinking_water        :decimal(, )
+#  pwsid                          :string           not null
+#  svi_overall_pctl               :decimal(5, 2)
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#
+# Indexes
+#
+#  index_environmental_justices_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :environmental_justice do
     association :public_water_system

--- a/spec/factories/funding_summaries.rb
+++ b/spec/factories/funding_summaries.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: funding_summaries
+#
+#  id                          :bigint           not null, primary key
+#  median_srf_assistance       :decimal(, )
+#  pwsid                       :string           not null
+#  times_funded                :integer
+#  total_principal_forgiveness :decimal(, )
+#  total_srf_assistance        :decimal(, )
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#
+# Indexes
+#
+#  index_funding_summaries_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :funding_summary do
     association :public_water_system

--- a/spec/factories/place_system_crosswalks.rb
+++ b/spec/factories/place_system_crosswalks.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: place_system_crosswalks
+#
+#  id                       :bigint           not null, primary key
+#  fraction_of_place        :decimal(, )
+#  fraction_of_service_area :decimal(, )
+#  geoid                    :string(7)        not null
+#  pwsid                    :string           not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_place_system_crosswalks_on_geoid_and_pwsid  (geoid,pwsid) UNIQUE
+#  index_place_system_crosswalks_on_pwsid            (pwsid)
+#
 FactoryBot.define do
   factory :place_system_crosswalk do
     association :public_water_system

--- a/spec/factories/public_water_systems.rb
+++ b/spec/factories/public_water_systems.rb
@@ -1,6 +1,46 @@
+# == Schema Information
+#
+# Table name: public_water_systems
+#
+#  area_sq_miles                :decimal(, )
+#  counties                     :text
+#  detailed_facility_report     :string
+#  ewg_report_link              :string
+#  first_reported_date          :string
+#  gw_sw_code                   :string
+#  is_grant_eligible            :boolean
+#  is_school_or_daycare         :boolean
+#  is_wholesaler                :boolean
+#  open_health_viol             :string
+#  owner_type                   :string
+#  phone_number                 :string
+#  pop_cat_5                    :string
+#  population_served_count      :integer
+#  primacy_agency               :string
+#  primacy_type                 :string
+#  primary_source_code          :string
+#  pws_name                     :string
+#  pwsid                        :string           not null, primary key
+#  service_area_type            :string
+#  service_connections_count    :integer
+#  source_water_protection_code :string
+#  stusps                       :string(2)
+#  symbology_field              :string
+#  years_operating              :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#
+# Indexes
+#
+#  index_public_water_systems_on_gw_sw_code    (gw_sw_code)
+#  index_public_water_systems_on_owner_type    (owner_type)
+#  index_public_water_systems_on_pop_cat_5     (pop_cat_5)
+#  index_public_water_systems_on_primacy_type  (primacy_type)
+#  index_public_water_systems_on_stusps        (stusps)
+#
 FactoryBot.define do
   factory :public_water_system do
-    sequence(:pwsid) { |n| "VT#{format('%07d', n)}" }
+    sequence(:pwsid) { |n| "VT#{format("%07d", n)}" }
     pws_name { "Green Mountain Water District" }
     stusps { "VT" }
     primacy_agency { "Vermont DEC" }

--- a/spec/factories/service_area_geometries.rb
+++ b/spec/factories/service_area_geometries.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: service_area_geometries
+#
+#  id         :bigint           not null, primary key
+#  centroid   :geometry         point, 4326
+#  geom       :geometry         multipolygon, 4326
+#  pwsid      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_service_area_geometries_on_centroid  (centroid) USING gist
+#  index_service_area_geometries_on_geom      (geom) USING gist
+#  index_service_area_geometries_on_pwsid     (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :service_area_geometry do
     association :public_water_system

--- a/spec/factories/tile_caches.rb
+++ b/spec/factories/tile_caches.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: tile_cache
+#
+#  layer :string           not null, primary key
+#  mvt   :binary
+#  x     :integer          not null, primary key
+#  y     :integer          not null, primary key
+#  z     :integer          not null, primary key
+#
+# Indexes
+#
+#  index_tile_cache_on_z_and_x_and_y  (z,x,y)
+#
 FactoryBot.define do
   factory :tile_cache do
     layer { "pws" }

--- a/spec/factories/trend_data.rb
+++ b/spec/factories/trend_data.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: trend_data
+#
+#  id                               :bigint           not null, primary key
+#  households_pct_change            :decimal(, )
+#  income_change_flag               :string
+#  lowest_quintile_pct_change       :decimal(, )
+#  mhi_pct_change                   :decimal(, )
+#  mhi_pct_change_capped            :decimal(, )
+#  poc_pct_change                   :decimal(, )
+#  population_change_flag           :string
+#  population_in_poverty_pct_change :decimal(, )
+#  population_pct_change            :decimal(, )
+#  population_pct_change_capped     :decimal(, )
+#  poverty_pct_change               :decimal(, )
+#  pwsid                            :string           not null
+#  unemployment_pct_change          :decimal(, )
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_trend_data_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :trend_datum do
     association :public_water_system

--- a/spec/factories/violations_summaries.rb
+++ b/spec/factories/violations_summaries.rb
@@ -1,3 +1,43 @@
+# == Schema Information
+#
+# Table name: violations_summaries
+#
+#  id                               :bigint           not null, primary key
+#  groundwater_rule_10yr            :integer
+#  groundwater_rule_5yr             :integer
+#  health_violations_10yr           :integer
+#  health_violations_5yr            :integer
+#  inorganic_chemicals_10yr         :integer
+#  inorganic_chemicals_5yr          :integer
+#  lead_and_copper_10yr             :integer
+#  lead_and_copper_5yr              :integer
+#  paperwork_violations_10yr        :integer
+#  paperwork_violations_5yr         :integer
+#  pwsid                            :string           not null
+#  radionuclides_10yr               :integer
+#  radionuclides_5yr                :integer
+#  stage_1_disinfectants_10yr       :integer
+#  stage_1_disinfectants_5yr        :integer
+#  stage_2_disinfectants_10yr       :integer
+#  stage_2_disinfectants_5yr        :integer
+#  surface_water_treatment_10yr     :integer
+#  surface_water_treatment_5yr      :integer
+#  synthetic_organic_chemicals_10yr :integer
+#  synthetic_organic_chemicals_5yr  :integer
+#  total_coliform_10yr              :integer
+#  total_coliform_5yr               :integer
+#  total_violations_10yr            :integer
+#  total_violations_5yr             :integer
+#  violations_all_years             :integer
+#  volatile_organic_chemicals_10yr  :integer
+#  volatile_organic_chemicals_5yr   :integer
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_violations_summaries_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :violations_summary do
     association :public_water_system

--- a/spec/factories/watershed_hazards.rb
+++ b/spec/factories/watershed_hazards.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: watershed_hazards
+#
+#  id                              :bigint           not null, primary key
+#  impaired_streams_303d           :integer
+#  npdes_permits                   :integer
+#  num_facilities                  :integer
+#  open_underground_storage_tanks  :integer
+#  permit_effluent_violations      :integer
+#  pwsid                           :string           not null
+#  risk_management_plan_facilities :integer
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#
+# Indexes
+#
+#  index_watershed_hazards_on_pwsid  (pwsid) UNIQUE
+#
 FactoryBot.define do
   factory :watershed_hazard do
     association :public_water_system

--- a/spec/models/boil_water_summary_spec.rb
+++ b/spec/models/boil_water_summary_spec.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: boil_water_summaries
+#
+#  id                       :bigint           not null, primary key
+#  date_range_display       :string
+#  download_url             :string
+#  first_advisory_date      :string
+#  last_advisory_date       :string
+#  pwsid                    :string           not null
+#  state                    :string
+#  state_reporting_year_max :string
+#  state_reporting_year_min :string
+#  tooltip_text             :text
+#  total_notices            :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_boil_water_summaries_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe BoilWaterSummary, type: :model do

--- a/spec/models/cartographic_county_spec.rb
+++ b/spec/models/cartographic_county_spec.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: cartographic_counties
+#
+#  countyfp :string(3)
+#  geoid    :string(5)
+#  geom     :geometry         multipolygon, 4326
+#  gid      :integer          not null, primary key
+#  name     :string
+#  namelsad :string
+#  statefp  :string(2)
+#  stusps   :string(2)
+#
+# Indexes
+#
+#  index_cartographic_counties_on_geom                 (geom) USING gist
+#  index_cartographic_counties_on_namelsad_and_stusps  (namelsad,stusps)
+#
 require "rails_helper"
 
 RSpec.describe CartographicCounty, type: :model do

--- a/spec/models/cartographic_place_spec.rb
+++ b/spec/models/cartographic_place_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: cartographic_places
+#
+#  affgeoid :string
+#  geoid    :string(7)
+#  geom     :geometry         multipolygon, 4326
+#  gid      :integer          not null, primary key
+#  name     :string
+#  namelsad :string
+#  placefp  :string(5)
+#  statefp  :string(2)
+#  stusps   :string(2)
+#
+# Indexes
+#
+#  index_cartographic_places_on_affgeoid  (affgeoid)
+#  index_cartographic_places_on_geoid     (geoid)
+#  index_cartographic_places_on_geom      (geom) USING gist
+#
 require "rails_helper"
 
 RSpec.describe CartographicPlace, type: :model do

--- a/spec/models/cartographic_state_spec.rb
+++ b/spec/models/cartographic_state_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: cartographic_states
+#
+#  geoid   :string(2)
+#  geom    :geometry         multipolygon, 4326
+#  gid     :integer          not null, primary key
+#  name    :string
+#  statefp :string(2)
+#  stusps  :string(2)
+#
+# Indexes
+#
+#  index_cartographic_states_on_geom  (geom) USING gist
+#
 require "rails_helper"
 
 RSpec.describe CartographicState, type: :model do

--- a/spec/models/concerns/filterable_spec.rb
+++ b/spec/models/concerns/filterable_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Filterable, type: :model do
         in_place = create(:public_water_system)
         out_of_place = create(:public_water_system)
         create(:place_system_crosswalk, public_water_system: in_place, cartographic_place: place,
-                                        pwsid: in_place.pwsid, geoid: place.geoid)
+          pwsid: in_place.pwsid, geoid: place.geoid)
 
         results = PublicWaterSystem.apply_filters(place_geoid: place.geoid)
         expect(results).to include(in_place)

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: data_imports
+#
+#  id          :bigint           not null, primary key
+#  file_url    :string           not null
+#  imported_at :datetime         not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_data_imports_on_file_url  (file_url)
+#
 require "rails_helper"
 
 RSpec.describe DataImport, type: :model do

--- a/spec/models/demographic_spec.rb
+++ b/spec/models/demographic_spec.rb
@@ -1,3 +1,45 @@
+# == Schema Information
+#
+# Table name: demographics
+#
+#  id                               :bigint           not null, primary key
+#  age_over_61_rate                 :decimal(5, 2)
+#  age_under_5_rate                 :decimal(5, 2)
+#  aian_rate                        :decimal(5, 2)
+#  asian_rate                       :decimal(5, 2)
+#  bachelors_degree_rate            :decimal(5, 2)
+#  black_rate                       :decimal(5, 2)
+#  hispanic_rate                    :decimal(5, 2)
+#  household_income_lowest_quintile :integer
+#  median_household_income          :integer
+#  mixed_race_rate                  :decimal(5, 2)
+#  most_common_rate_tier            :string
+#  napi_rate                        :decimal(5, 2)
+#  no_health_insurance_rate         :decimal(5, 2)
+#  other_race_rate                  :decimal(5, 2)
+#  owner_rate                       :decimal(5, 2)
+#  poc_rate                         :decimal(5, 2)
+#  population_density               :decimal(, )
+#  population_in_poverty_rate       :decimal(5, 2)
+#  poverty_rate                     :decimal(5, 2)
+#  pwsid                            :string           not null
+#  renter_rate                      :decimal(5, 2)
+#  total_population                 :integer
+#  unemployment_rate                :decimal(5, 2)
+#  water_rate_125_249               :decimal(5, 2)
+#  water_rate_250_499               :decimal(5, 2)
+#  water_rate_500_749               :decimal(5, 2)
+#  water_rate_750_999               :decimal(5, 2)
+#  water_rate_over_1000             :decimal(5, 2)
+#  water_rate_under_125             :decimal(5, 2)
+#  white_rate                       :decimal(5, 2)
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_demographics_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe Demographic, type: :model do

--- a/spec/models/environmental_justice_spec.rb
+++ b/spec/models/environmental_justice_spec.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: environmental_justices
+#
+#  id                             :bigint           not null, primary key
+#  cejst_disadvantaged_pct        :decimal(5, 2)
+#  cejst_lead_paint_indicator     :integer
+#  cejst_low_life_expectancy_pctl :decimal(, )
+#  cvi_cancer_risk                :decimal(, )
+#  cvi_life_expectancy            :decimal(, )
+#  cvi_overall_score              :decimal(5, 2)
+#  cvi_redlining                  :decimal(, )
+#  ejscreen_disability_rate       :decimal(, )
+#  ejscreen_drinking_water        :decimal(, )
+#  pwsid                          :string           not null
+#  svi_overall_pctl               :decimal(5, 2)
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#
+# Indexes
+#
+#  index_environmental_justices_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe EnvironmentalJustice, type: :model do

--- a/spec/models/funding_summary_spec.rb
+++ b/spec/models/funding_summary_spec.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: funding_summaries
+#
+#  id                          :bigint           not null, primary key
+#  median_srf_assistance       :decimal(, )
+#  pwsid                       :string           not null
+#  times_funded                :integer
+#  total_principal_forgiveness :decimal(, )
+#  total_srf_assistance        :decimal(, )
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#
+# Indexes
+#
+#  index_funding_summaries_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe FundingSummary, type: :model do

--- a/spec/models/place_system_crosswalk_spec.rb
+++ b/spec/models/place_system_crosswalk_spec.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: place_system_crosswalks
+#
+#  id                       :bigint           not null, primary key
+#  fraction_of_place        :decimal(, )
+#  fraction_of_service_area :decimal(, )
+#  geoid                    :string(7)        not null
+#  pwsid                    :string           not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_place_system_crosswalks_on_geoid_and_pwsid  (geoid,pwsid) UNIQUE
+#  index_place_system_crosswalks_on_pwsid            (pwsid)
+#
 require "rails_helper"
 
 RSpec.describe PlaceSystemCrosswalk, type: :model do

--- a/spec/models/public_water_system_spec.rb
+++ b/spec/models/public_water_system_spec.rb
@@ -1,3 +1,43 @@
+# == Schema Information
+#
+# Table name: public_water_systems
+#
+#  area_sq_miles                :decimal(, )
+#  counties                     :text
+#  detailed_facility_report     :string
+#  ewg_report_link              :string
+#  first_reported_date          :string
+#  gw_sw_code                   :string
+#  is_grant_eligible            :boolean
+#  is_school_or_daycare         :boolean
+#  is_wholesaler                :boolean
+#  open_health_viol             :string
+#  owner_type                   :string
+#  phone_number                 :string
+#  pop_cat_5                    :string
+#  population_served_count      :integer
+#  primacy_agency               :string
+#  primacy_type                 :string
+#  primary_source_code          :string
+#  pws_name                     :string
+#  pwsid                        :string           not null, primary key
+#  service_area_type            :string
+#  service_connections_count    :integer
+#  source_water_protection_code :string
+#  stusps                       :string(2)
+#  symbology_field              :string
+#  years_operating              :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#
+# Indexes
+#
+#  index_public_water_systems_on_gw_sw_code    (gw_sw_code)
+#  index_public_water_systems_on_owner_type    (owner_type)
+#  index_public_water_systems_on_pop_cat_5     (pop_cat_5)
+#  index_public_water_systems_on_primacy_type  (primacy_type)
+#  index_public_water_systems_on_stusps        (stusps)
+#
 require "rails_helper"
 
 RSpec.describe PublicWaterSystem, type: :model do
@@ -148,7 +188,7 @@ RSpec.describe PublicWaterSystem, type: :model do
         in_place = create(:public_water_system)
         out_of_place = create(:public_water_system)
         create(:place_system_crosswalk, public_water_system: in_place, cartographic_place: place,
-                                        pwsid: in_place.pwsid, geoid: place.geoid)
+          pwsid: in_place.pwsid, geoid: place.geoid)
 
         results = described_class.apply_filters(place_geoid: place.geoid)
         expect(results).to include(in_place)

--- a/spec/models/service_area_geometry_spec.rb
+++ b/spec/models/service_area_geometry_spec.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: service_area_geometries
+#
+#  id         :bigint           not null, primary key
+#  centroid   :geometry         point, 4326
+#  geom       :geometry         multipolygon, 4326
+#  pwsid      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_service_area_geometries_on_centroid  (centroid) USING gist
+#  index_service_area_geometries_on_geom      (geom) USING gist
+#  index_service_area_geometries_on_pwsid     (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe ServiceAreaGeometry, type: :model do

--- a/spec/models/tile_cache_spec.rb
+++ b/spec/models/tile_cache_spec.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: tile_cache
+#
+#  layer :string           not null, primary key
+#  mvt   :binary
+#  x     :integer          not null, primary key
+#  y     :integer          not null, primary key
+#  z     :integer          not null, primary key
+#
+# Indexes
+#
+#  index_tile_cache_on_z_and_x_and_y  (z,x,y)
+#
 require "rails_helper"
 
 RSpec.describe TileCache, type: :model do

--- a/spec/models/trend_datum_spec.rb
+++ b/spec/models/trend_datum_spec.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: trend_data
+#
+#  id                               :bigint           not null, primary key
+#  households_pct_change            :decimal(, )
+#  income_change_flag               :string
+#  lowest_quintile_pct_change       :decimal(, )
+#  mhi_pct_change                   :decimal(, )
+#  mhi_pct_change_capped            :decimal(, )
+#  poc_pct_change                   :decimal(, )
+#  population_change_flag           :string
+#  population_in_poverty_pct_change :decimal(, )
+#  population_pct_change            :decimal(, )
+#  population_pct_change_capped     :decimal(, )
+#  poverty_pct_change               :decimal(, )
+#  pwsid                            :string           not null
+#  unemployment_pct_change          :decimal(, )
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_trend_data_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe TrendDatum, type: :model do

--- a/spec/models/violations_summary_spec.rb
+++ b/spec/models/violations_summary_spec.rb
@@ -1,3 +1,43 @@
+# == Schema Information
+#
+# Table name: violations_summaries
+#
+#  id                               :bigint           not null, primary key
+#  groundwater_rule_10yr            :integer
+#  groundwater_rule_5yr             :integer
+#  health_violations_10yr           :integer
+#  health_violations_5yr            :integer
+#  inorganic_chemicals_10yr         :integer
+#  inorganic_chemicals_5yr          :integer
+#  lead_and_copper_10yr             :integer
+#  lead_and_copper_5yr              :integer
+#  paperwork_violations_10yr        :integer
+#  paperwork_violations_5yr         :integer
+#  pwsid                            :string           not null
+#  radionuclides_10yr               :integer
+#  radionuclides_5yr                :integer
+#  stage_1_disinfectants_10yr       :integer
+#  stage_1_disinfectants_5yr        :integer
+#  stage_2_disinfectants_10yr       :integer
+#  stage_2_disinfectants_5yr        :integer
+#  surface_water_treatment_10yr     :integer
+#  surface_water_treatment_5yr      :integer
+#  synthetic_organic_chemicals_10yr :integer
+#  synthetic_organic_chemicals_5yr  :integer
+#  total_coliform_10yr              :integer
+#  total_coliform_5yr               :integer
+#  total_violations_10yr            :integer
+#  total_violations_5yr             :integer
+#  violations_all_years             :integer
+#  volatile_organic_chemicals_10yr  :integer
+#  volatile_organic_chemicals_5yr   :integer
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#
+# Indexes
+#
+#  index_violations_summaries_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe ViolationsSummary, type: :model do

--- a/spec/models/watershed_hazard_spec.rb
+++ b/spec/models/watershed_hazard_spec.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: watershed_hazards
+#
+#  id                              :bigint           not null, primary key
+#  impaired_streams_303d           :integer
+#  npdes_permits                   :integer
+#  num_facilities                  :integer
+#  open_underground_storage_tanks  :integer
+#  permit_effluent_violations      :integer
+#  pwsid                           :string           not null
+#  risk_management_plan_facilities :integer
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#
+# Indexes
+#
+#  index_watershed_hazards_on_pwsid  (pwsid) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe WatershedHazard, type: :model do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,13 +1,13 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
-require 'rspec/rails'
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob("spec/support/**/*.rb").sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to
@@ -40,7 +40,7 @@ RSpec.configure do |config|
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
-    Rails.root.join('spec/fixtures')
+    Rails.root.join("spec/fixtures")
   ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
## Summary

Three developer-experience improvements flagged in a codebase review: a domain glossary for the EPA-heavy terminology, inline schema annotations on all models, and a switch from `rubocop-rails-omakase` to StandardRB.

## Changes

- **Glossary** — new `docs/GLOSSARY.md` covering ~30 domain acronyms (PWSID, SABS, SDWIS, SRF, CEJST, SVI, CVI, MVT, etc.), EPA data source descriptions, water system classification code values, and PostGIS/tile technical terms
- **Model annotations** — all 15 models (plus their specs and factories) now have `# == Schema Information` comment blocks generated by `annotaterb`; a post-`db:migrate` Rake hook keeps them current automatically
- **StandardRB** — replaced `rubocop-rails-omakase` with `standardrb` + `standard-rails`; deleted `.rubocop.yml`, added `.standard.yml`; updated `bin/rubocop` to invoke StandardRB so `bin/ci` and the GitHub Actions lint step require no changes; auto-corrected 224 style violations surfaced by the stricter ruleset

## Notes for reviewers

The annotaterb gem annotates spec files and factories in addition to model files — that accounts for the bulk of the line count here. The actual model changes are just the prepended comment blocks.

StandardRB downgraded RuboCop from 1.86 → 1.84.2 to satisfy `standard`'s version constraint. No runtime impact.
