### PR TITLE
[FEAT] Polish up UI post Initial V2 Demo Deploy

### DIFF
--- a/app/assets/stylesheets/water_tool.css
+++ b/app/assets/stylesheets/water_tool.css
@@ -463,6 +463,17 @@ body{
   z-index: 5;
 }
 
+#container-map-ui-top ul {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 5px 20px 0 5px;
+}
+
+.geocoder-li {
+  margin-right: auto;
+}
+
 #container-map-ui-top ul li a{
   background: url(icon-nav-arrow-down.png) 85% 14px no-repeat;
   background-size: 14px;
@@ -991,7 +1002,7 @@ ul.stats-list li{
 
 .container-menu{
   position: inherit;
-  top: 60px;
+  top: 72px;
   z-index: 1001;
   background-color: #fff;
   border-top:none;
@@ -1006,7 +1017,7 @@ ul.stats-list li{
 
 .container-filter-count{
   background-color: #4EA324;
-  display: inline-block;
+  display: none;
   color: #fff;
   font-size: .7em;
   border-radius: 50px;
@@ -1149,6 +1160,10 @@ ul.stats-list li{
 .container-menu ul li:hover .btn-filter-options img{
   display:block;
 }
+.filter-coming-soon {
+  color: #888;
+}
+
 .container-menu-more li.filter-clear{
   border-top: 1px solid #b9b9b9;
   padding-top: 5px;

--- a/app/javascript/controllers/filter_controller.js
+++ b/app/javascript/controllers/filter_controller.js
@@ -14,11 +14,14 @@ export default class extends Controller {
       }
     }
     document.addEventListener("click", this._outsideClick)
+    this.#setupResponsiveFilters()
     this.#restoreFromUrl()
+    this.#updateBadges()
   }
 
   disconnect() {
     document.removeEventListener("click", this._outsideClick)
+    this.#teardownResponsiveFilters()
   }
 
   toggleMenu(event) {
@@ -31,12 +34,17 @@ export default class extends Controller {
     const isOpen = menu.style.display === "block"
     this.#closeAll()
     if (!isOpen) {
-      // Align menu below the button that triggered it
       const mapRect = document.getElementById("container-map").getBoundingClientRect()
       const btnRect = btn.getBoundingClientRect()
-      menu.style.left = `${btnRect.left - mapRect.left}px`
+
+      // Show first so offsetWidth is accurate, then clamp to avoid right-edge overflow
+      menu.style.left = "0"
       menu.style.display = "block"
       btn.classList.add("active")
+
+      const leftPos = btnRect.left - mapRect.left
+      const maxLeft = mapRect.width - menu.offsetWidth - 10
+      menu.style.left = `${Math.max(0, Math.min(leftPos, maxLeft))}px`
     }
   }
 
@@ -45,7 +53,14 @@ export default class extends Controller {
     this.#closeAll()
     FilterState.set(this.#collectFilters())
     this.#syncToUrl()
+    this.#updateBadges()
     document.dispatchEvent(new CustomEvent("filters:changed"))
+  }
+
+  resetAll(event) {
+    event.preventDefault()
+    document.querySelectorAll(".container-menu").forEach(menu => this.#resetMenu(menu))
+    this.apply(event)
   }
 
   toggleSelectAll(event) {
@@ -85,34 +100,23 @@ export default class extends Controller {
     event.preventDefault()
     const menu = event.currentTarget.closest(".container-menu")
     if (!menu) return
-
-    // Radios: check the option marked with data-default, uncheck others
-    menu.querySelectorAll("input[type='radio']").forEach(r => {
-      r.checked = r.hasAttribute("data-default")
-    })
-
-    // Checkboxes: restore to default state (checked if .default-checked)
-    menu.querySelectorAll("input[type='checkbox']").forEach(cb => {
-      cb.checked = cb.classList.contains("default-checked")
-    })
-
-    // Selects: min → first option, max → last option
-    menu.querySelectorAll("select.min-select").forEach(s => { s.selectedIndex = 0 })
-    menu.querySelectorAll("select.max-select").forEach(s => { s.selectedIndex = s.options.length - 1 })
-
-    // Population size boxes: deactivate all
-    menu.querySelectorAll(".pop-size-box").forEach(b => b.classList.remove("active"))
-
-    // Place autocomplete: clear hidden field if present
-    const placeInput = menu.querySelector("#place-geoid")
-    if (placeInput) placeInput.value = ""
-    const placeText = menu.querySelector(".js-place-search")
-    if (placeText) placeText.value = ""
-
+    this.#resetMenu(menu)
     this.apply(event)
   }
 
   // ── Private ────────────────────────────────────────────────────────────────
+
+  #resetMenu(menu) {
+    menu.querySelectorAll("input[type='radio']").forEach(r => { r.checked = r.hasAttribute("data-default") })
+    menu.querySelectorAll("input[type='checkbox']").forEach(cb => { cb.checked = cb.classList.contains("default-checked") })
+    menu.querySelectorAll("select.min-select").forEach(s => { s.selectedIndex = 0 })
+    menu.querySelectorAll("select.max-select").forEach(s => { s.selectedIndex = s.options.length - 1 })
+    menu.querySelectorAll(".pop-size-box").forEach(b => b.classList.remove("active"))
+    const placeInput = menu.querySelector("#place-geoid")
+    if (placeInput) placeInput.value = ""
+    const placeText = menu.querySelector(".js-place-search")
+    if (placeText) placeText.value = ""
+  }
 
   #closeAll() {
     document.querySelectorAll(".container-menu").forEach(m => { m.style.display = "none" })
@@ -190,6 +194,18 @@ export default class extends Controller {
       const placeInput = document.querySelector(".js-place-search")
       if (placeInput?.value) p.place_name = placeInput.value
     }
+
+    // --- More: funding ---
+    if (document.getElementById("more-has-srf-financing")?.checked) p.times_funded_min = "1"
+    if (document.getElementById("more-has-srf-assistance")?.checked) p.total_srf_assistance_min = "1"
+    if (document.getElementById("more-has-principal-forgiveness")?.checked) p.total_principal_forgiveness_min = "1"
+
+    // --- More: watershed hazards ---
+    if (document.getElementById("more-num-facilities")?.checked) p.num_facilities_min = "1"
+    if (document.getElementById("more-permit-effluent-violations")?.checked) p.permit_effluent_violations_min = "1"
+    if (document.getElementById("more-open-usts")?.checked) p.open_underground_storage_tanks_min = "1"
+    if (document.getElementById("more-rmps")?.checked) p.risk_management_plan_facilities_min = "1"
+    if (document.getElementById("more-impaired-streams")?.checked) p.impaired_streams_303d_min = "1"
 
     return p
   }
@@ -297,5 +313,156 @@ export default class extends Controller {
       const input = document.querySelector(".js-place-search")
       if (input) input.value = params.place_name || params.place_geoid
     }
+
+    // More: funding
+    if (params.times_funded_min) {
+      const el = document.getElementById("more-has-srf-financing")
+      if (el) el.checked = true
+    }
+    if (params.total_srf_assistance_min) {
+      const el = document.getElementById("more-has-srf-assistance")
+      if (el) el.checked = true
+    }
+    if (params.total_principal_forgiveness_min) {
+      const el = document.getElementById("more-has-principal-forgiveness")
+      if (el) el.checked = true
+    }
+
+    // More: watershed hazards
+    if (params.num_facilities_min) {
+      const el = document.getElementById("more-num-facilities")
+      if (el) el.checked = true
+    }
+    if (params.permit_effluent_violations_min) {
+      const el = document.getElementById("more-permit-effluent-violations")
+      if (el) el.checked = true
+    }
+    if (params.open_underground_storage_tanks_min) {
+      const el = document.getElementById("more-open-usts")
+      if (el) el.checked = true
+    }
+    if (params.risk_management_plan_facilities_min) {
+      const el = document.getElementById("more-rmps")
+      if (el) el.checked = true
+    }
+    if (params.impaired_streams_303d_min) {
+      const el = document.getElementById("more-impaired-streams")
+      if (el) el.checked = true
+    }
+  }
+
+  #updateBadges() {
+    const p = FilterState.get()
+
+    const groupKeys = {
+      1: ["gw_sw_code", "has_source_protection", "place_geoid"],
+      2: ["owner_type", "primacy_type", "is_wholesaler", "is_school_or_daycare"],
+      3: ["symbology_field", "area_min", "area_max"],
+      4: ["has_open_violations", "health_violations_5yr_min", "health_violations_10yr_min", "paperwork_violations_5yr_min", "paperwork_violations_10yr_min"],
+      5: ["pop_cat_5", "density_min", "density_max"],
+      10: ["times_funded_min", "total_srf_assistance_min", "total_principal_forgiveness_min", "num_facilities_min", "permit_effluent_violations_min", "open_underground_storage_tanks_min", "risk_management_plan_facilities_min", "impaired_streams_303d_min"]
+    }
+
+    const countKeys = (keys) => keys.filter(k => {
+      const val = p[k]
+      return val !== undefined && val !== null && val !== ""
+    }).length
+
+    // Groups 1–5: if collapsed into More, add their count to More's badge instead
+    let moreCount = countKeys(groupKeys[10])
+
+    for (const [groupStr, keys] of Object.entries(groupKeys)) {
+      const group = Number(groupStr)
+      if (group === 10) continue
+
+      const li = document.querySelector(`.filter-${group}`)
+      const count = countKeys(keys)
+
+      if (li?.classList.contains("hidden")) {
+        moreCount += count
+      } else {
+        const badge = document.querySelector(`.container-filter-count-menu-${group}`)
+        if (!badge) continue
+        const span = badge.querySelector("span")
+        if (count > 0) {
+          badge.style.display = "inline-block"
+          if (span) span.textContent = count
+        } else {
+          badge.style.display = "none"
+        }
+      }
+    }
+
+    const moreBadge = document.querySelector(".container-filter-count-menu-10")
+    if (moreBadge) {
+      const span = moreBadge.querySelector("span")
+      if (moreCount > 0) {
+        moreBadge.style.display = "inline-block"
+        if (span) span.textContent = moreCount
+      } else {
+        moreBadge.style.display = "none"
+      }
+    }
+  }
+
+  // Breakpoints match the legacy app (adjusted for map container width rather than window width).
+  // When a nav button hides, its content div is physically moved into the More menu so it remains
+  // accessible there — same DOM-reparenting pattern as the legacy scripts-ui.js setLayout().
+  #RESPONSIVE_FILTERS = [
+    { num: 5, breakpoint: 1190 },  // Population
+    { num: 4, breakpoint: 1040 },  // Compliance
+    { num: 3, breakpoint: 880 },   // Boundaries
+    { num: 2, breakpoint: 730 },   // Attributes
+  ]
+
+  #resizeObserver = null
+  #lastLayoutWidth = null
+
+  #setupResponsiveFilters() {
+    this.#resizeObserver = new ResizeObserver(entries => {
+      this.#closeAll()
+      this.#adjustFilterLayout(entries[0].contentRect.width)
+    })
+    const mapEl = document.getElementById("container-map")
+    if (mapEl) {
+      this.#resizeObserver.observe(mapEl)
+      this.#adjustFilterLayout(mapEl.clientWidth)
+    }
+  }
+
+  #teardownResponsiveFilters() {
+    this.#resizeObserver?.disconnect()
+    this.#resizeObserver = null
+  }
+
+  #adjustFilterLayout(width) {
+    // Skip if no breakpoint was crossed since the last pass — avoids badge recalc on every resize pixel
+    const prev = this.#lastLayoutWidth
+    const crossed = prev === null || this.#RESPONSIVE_FILTERS.some(({ breakpoint }) =>
+      (prev < breakpoint) !== (width < breakpoint)
+    )
+    if (!crossed) return
+    this.#lastLayoutWidth = width
+
+    for (const { num, breakpoint } of this.#RESPONSIVE_FILTERS) {
+      const li = document.querySelector(`.filter-${num}`)
+      const items = document.getElementById(`container-menu-${num}-items`)
+      const mainGrp = document.getElementById(`main-filter-grp-${num}`)
+      const moreGrp = document.getElementById(`more-filter-grp-${num}`)
+      if (!li || !items || !mainGrp || !moreGrp) continue
+
+      if (width < breakpoint) {
+        li.classList.add("hidden")
+        // items becomes the next sibling of moreGrp — stable because moreGrp is always
+        // immediately followed by items (or nothing) inside the More container
+        moreGrp.insertAdjacentElement("afterend", items)
+      } else {
+        li.classList.remove("hidden")
+        // items becomes the next sibling of mainGrp — stable because the original HTML
+        // always places container-menu-N-items directly after main-filter-grp-N
+        mainGrp.insertAdjacentElement("afterend", items)
+      }
+    }
+    this.#updateBadges()
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -46,6 +46,7 @@ export default class extends Controller {
     this.#addControls()
     this.#addSource()
     this.#addLayers()
+    this.#styleWater()
     this.#bindEvents()
 
     // Once the initial tiles settle, animate to working zoom and reveal the UI
@@ -261,6 +262,16 @@ export default class extends Controller {
         "circle-stroke-color": "#000",
         "circle-stroke-width": 1,
         "circle-opacity": 0.7
+      }
+    })
+  }
+
+  #styleWater() {
+    // Override the base style's water color to match the legacy blue ocean look.
+    // light-v11 defaults to near-white water; this restores a readable blue.
+    ["water", "water-shadow"].forEach(layerId => {
+      if (this.map.getLayer(layerId)) {
+        this.map.setPaintProperty(layerId, "fill-color", "#a8d0e4")
       }
     })
   }

--- a/app/views/home/_filter_menus.html.erb
+++ b/app/views/home/_filter_menus.html.erb
@@ -116,7 +116,7 @@
     </ul>
     <h3>Notices</h3>
     <ul>
-      <li><input type="checkbox" class="toggle" disabled="disabled" id="boil-water-notices"><label style="color: #888;" for="boil-water-notices">Boil water notices <span class="bwn-disabled-txt">(data unavailable <span class="geo-filter"></span>)</span></label></li>
+      <li><input type="checkbox" class="toggle" disabled="disabled" id="boil-water-notices"><label class="filter-coming-soon" for="boil-water-notices">Boil water notices <span class="bwn-disabled-txt">(data unavailable <span class="geo-filter"></span>)</span></label></li>
     </ul>
   </div>
   <div class="filter-menu-footer">
@@ -125,16 +125,40 @@
   </div>
 </div>
 
-<!-- 10. MORE (aggregates filters from groups 1–5 that overflow the tab bar) -->
+<!-- 10. MORE -->
 <div id="container-menu-10" class="container-menu container-menu-more" style="display:none;">
   <h2 class="hide-for-mobile">More filters</h2>
+  <%# Placeholders — filter content moves here when its nav button collapses %>
   <div id="more-filter-grp-1"></div>
   <div id="more-filter-grp-2"></div>
   <div id="more-filter-grp-3"></div>
   <div id="more-filter-grp-4"></div>
   <div id="more-filter-grp-5"></div>
+  <div id="container-menu-10-items">
+    <h3>Financial</h3>
+    <ul>
+      <li>
+        <input type="checkbox" class="toggle" id="more-rate-tier" disabled="disabled">
+        <label for="more-rate-tier" class="filter-coming-soon">Annual water and sewer bill <em>(TBD)</em></label>
+      </li>
+    </ul>
+    <h3>Funding (2021–2025)</h3>
+    <ul>
+      <li><input type="checkbox" class="toggle" id="more-has-srf-financing"><label for="more-has-srf-financing">State revolving fund financing</label></li>
+      <li><input type="checkbox" class="toggle" id="more-has-srf-assistance"><label for="more-has-srf-assistance">State revolving fund assistance</label></li>
+      <li><input type="checkbox" class="toggle" id="more-has-principal-forgiveness"><label for="more-has-principal-forgiveness">State revolving fund principal forgiveness</label></li>
+    </ul>
+    <h3>Environmental</h3>
+    <ul>
+      <li><input type="checkbox" class="toggle" id="more-num-facilities"><label for="more-num-facilities">Source water connections</label></li>
+      <li><input type="checkbox" class="toggle" id="more-permit-effluent-violations"><label for="more-permit-effluent-violations">Pollution permits with breaches</label></li>
+      <li><input type="checkbox" class="toggle" id="more-open-usts"><label for="more-open-usts">Underground storage tanks</label></li>
+      <li><input type="checkbox" class="toggle" id="more-rmps"><label for="more-rmps">Risk management plan facilities</label></li>
+      <li><input type="checkbox" class="toggle" id="more-impaired-streams"><label for="more-impaired-streams">Streams with impaired or threatened surface waters</label></li>
+    </ul>
+  </div>
   <div class="filter-menu-footer">
-    <a href="javascript:void(0);" class="btn-filters" data-action="click->filter#reset">Reset</a>
+    <a href="javascript:void(0);" class="btn-filters" data-action="click->filter#resetAll">Reset All</a>
     <a href="javascript:void(0);" class="btn-filters btn-apply-filters" data-action="click->filter#apply">Apply</a>
   </div>
 </div>

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -161,9 +161,101 @@ If Ohio doesn't cover both, try California or Texas next.
 
 ---
 
+## Filter UI — Minor Parity Items
+
+Small behavioral gaps from the legacy app that remain unaddressed.
+
+---
+
+### Attributes Filter — New Filters Need Verification
+
+V2 added four filters not present in legacy: Wholesaler, School or daycare, Tribal (owner), and Territory (primacy). These are wired to the backend but have not been verified against expected behavior in production data. The VT/RI dev seed returns zero results for all four (see Dev Seed Data section below), so testing requires production data or a richer seed state.
+
+**Priority:** Low — verify before public launch.
+
+---
+
+### Filter Button Badge — `has-filter` Green Highlight
+
+- **Legacy:** Filter button links receive a `has-filter` CSS class when their group has active filters, producing a green highlight
+- **V2:** Badge counts show correctly but `has-filter` is never applied — buttons don't turn green when filters are active
+- **What to do:** In `#updateBadges`, add/remove `has-filter` on the `.filter-menu-btn` `<a>` for each group based on whether its count is > 0
+- **Priority:** Low — cosmetic, does not affect functionality
+
+---
+
+### Filter Badge Counts — Verify Match with Legacy
+
+- **Legacy:** Used a `filterGroupCounts` object to track counts per group
+- **V2:** Counts active param keys per group using a hardcoded key list in `#updateBadges`
+- **What to verify:** Spot-check each filter group (Source, Attributes, Boundaries, Compliance, Population, More) with known filter combinations and confirm V2 badge counts match what legacy showed
+- **Priority:** Low — verify before public launch
+
+---
+
+## Filter Parity Gaps — Legacy vs V2
+
+Filters present in the legacy app that are missing from the V2 UI. Backend filter logic is noted for each.
+
+---
+
+### Population — Demographic & Environmental Justice Filters *(largest gap)*
+
+The legacy Population filter had a full demographic panel with histogram range sliders. V2 only shows size categories and density. All of the following have range filters (`_min`/`_max`) already wired in `Filterable` and data in the `demographics` or `environmental_justices` tables — this is purely a UI gap.
+
+**Trend data** (wired: `trend_data` table, `population_pct_change`, `mhi_pct_change`):
+- Change in people served (last 10 years)
+- Change in median household income (last 10 years)
+
+**Demographic data** (wired: `demographics` table):
+- Households below the poverty line (`poverty_rate`)
+- Unemployment (`unemployment_rate`)
+- Annual median household income (`median_household_income`)
+- Higher education attainment (`bachelors_degree_rate`)
+- Children under 5 (`age_under_5_rate`)
+- Elderly over 61 (`age_over_61_rate`)
+- People of color (`poc_rate`)
+- Race/ethnicity breakdowns: White, Black, Asian, American Indian & Alaskan Native, Native Hawaiian & Pacific Islander, Latino/a, Other, Mixed race
+
+**Environmental justice** (wired: `environmental_justices` table):
+- Disadvantaged area / CEJST (`cejst_disadvantaged_pct`)
+- Social Vulnerability Index (`svi_overall_pctl`)
+- Climate Vulnerability Index (`cvi_overall_score`)
+
+**Note:** Legacy used histogram sliders for all of these. The V2 slider infrastructure exists (`slider_controller.js`) but none of these fields are surfaced in the Population filter UI.
+
+**Priority:** Medium — significant feature gap, but requires substantial UI work. Backend is ready.
+
+---
+
+### Compliance — EJScreen Drinking Water Score
+
+- **Legacy:** "2024 EJScreen Score" checkbox in the Compliance filter
+- **V2:** Column `ejscreen_drinking_water` exists in the `demographics` table but no filter param is wired in `Filterable` and no UI exists
+- **Priority:** Low — needs both backend filter wiring and UI
+
+---
+
+### Source — Water Source Sub-types
+
+- **Legacy:** The Source filter had granular sub-type checkboxes under Ground (purchased, non-purchased, surface-influenced) and Surface (purchased, non-purchased)
+- **V2:** Only the top-level Both/Ground/Surface radio buttons exist; `gw_sw_code` is a single-value filter, not multi-select
+- **Priority:** Low — adds precision but the top-level radios cover the common cases
+
+---
+
+### Financial — Annual Water and Sewer Bill
+
+- **Legacy:** Expanded into a bucket picker with 7 dollar-range tiers (< $125 through > $1000), filtering on `most_common_rate_tidy`
+- **V2:** `most_common_rate_tier` column exists in `demographics` and is partially wired in `Filterable`, but the bucket picker UI is not built and the data values need to be confirmed. Shown in the UI as disabled / TBD.
+- **Priority:** Low — needs data value audit + bucket picker UI
+
+---
+
 ## Other
 
 - Ensure Mapbox access token is not exposed in request/response data visible in browser devtools
 - Add a warning when opening the Rails console, running specs, or starting the server if there are pending migrations
 - Add gems: `simplecov`, `lefthook`
-- "More" filter dropdown on the homepage — needs additional filters wired up and the reset button enabled
+- Home Page - add `Last Updated On:` and calculation logic
+

--- a/spec/tasks/cartographic_boundaries_rake_spec.rb
+++ b/spec/tasks/cartographic_boundaries_rake_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe "cartographic rake tasks" do
       before do
         # Track system calls; ogr2ogr uses array form, unzip uses array form
         allow_any_instance_of(Object).to receive(:system) do |_obj, *args|
-          cmd = args.join(" ")
           if args.first == "ogr2ogr"
             ogr2ogr_calls << args
           elsif args.first == "unzip"


### PR DESCRIPTION
## Summary

Fixes a set of UI parity issues between V2 and the legacy PHP app, focusing on filter bar layout, responsive behavior, dropdown content, map styling, and filter coverage. Changes were driven by side-by-side comparison of the two apps and are scoped to demo readiness.

## Changes

**Filter bar layout and responsiveness**
- Right-aligned the filter button group to match legacy; geocoder search stays pinned left
- Filter buttons now collapse right-to-left as the map container shrinks (Population → Compliance → Boundaries → Attributes), matching legacy breakpoints; collapsed groups are DOM-reparented into the More dropdown so their content stays accessible
- Open dropdowns now close on any resize event, preventing stale positioning after expand/collapse

**Dropdown positioning**
- Fixed horizontal overflow: menus now show-then-measure before positioning, clamping to the right edge of the map container
- Increased vertical gap between the filter bar and dropdown menus (60px → 72px)

**Filter badge counters**
- Badges are hidden at 0 and show active filter count when > 0
- When a filter group collapses into More, its active count rolls up into the More badge

**More dropdown — content and behavior**
- Was entirely empty; now has Financial, Funding (2021–2025), and Environmental sections
- Funding filters (SRF financing, assistance, principal forgiveness) are fully wired to the backend
- Environmental section exposes all five watershed hazard sub-filters as individual checkboxes, each wired to its backend range filter (source water connections, pollution permits, underground storage tanks, risk management plan facilities, impaired streams)
- Financial "Annual water and sewer bill" is visible but disabled (marked TBD — backend data needs audit before UI can be built)
- Reset button changed to "Reset All" — now clears all active filters across every group before applying, not just the More menu

**Ocean / water color**
- The legacy app used a private CNT Mapbox Studio style for blue water that will break when the CNT account changes; V2 now overrides the `light-v11` water layer paint property directly, restoring a readable blue with no external dependency

**Documentation**
- Added a full filter parity gap audit to `docs/TODO.md` covering every legacy filter not yet in V2, with backend wiring status and priority notes for each

## Notes for reviewers

The responsive collapse replicates the legacy jQuery `insertAfter()` DOM-reparenting approach using `insertAdjacentElement("afterend", ...)` with a `ResizeObserver`. The stable-sibling assumption (each filter group's `*-items` div is always the immediate next sibling of its `*-grp` placeholder) is documented in inline comments.

There is no JS test infrastructure in this project (RSpec only), so the new Stimulus controller behaviors are untested — consistent with the rest of the frontend.

The watershed hazard Environmental filters are flat checkboxes rather than the legacy expand/collapse parent pattern. The data and backend filters exist; building the parent/child UI is noted in `docs/TODO.md` as a future item.
