### PR TITLE
[FIX] Improve TileCache Generation and Homepage Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ bin/rails 'db:seed:states[VT,RI,OH,CO,PR]'
 rm -rf tmp/seeds/ && bin/rails 'db:seed:states[VT,RI,OH,CO,PR]'
 
 # Run full ETL import — loads the entire national dataset (~70k systems)
-# Requires ETL_SOURCE_URL + AWS credentials. Safe to run locally for
-# performance testing (exports, large filter sets, map rendering at scale).
+# Requires ETL_SOURCE_URL. Safe to run locally for performance testing
+# (exports, large filter sets, map rendering at scale).
 bin/rails etl:import
 
 # Run ETL import (single table)
@@ -167,6 +167,20 @@ bin/rails 'etl:import[epa_sabs]'
 # Stop PostgreSQL
 docker compose down
 ```
+
+### Background jobs and tile cache warming
+
+`TileCacheWarmJob` runs automatically after each ETL import to pre-generate z0–z8 map tiles using US region bounding boxes, so the initial national map view is fast for every user.
+
+In production, SolidQueue processes this job as a persistent background worker. In development, the ETL runs as a short-lived rake task (`bin/rails etl:import`) — the warm job is enqueued but the process exits before the job completes, so **the warm job never runs automatically in dev**.
+
+After loading the national dataset locally, warm the tile cache manually:
+
+```bash
+bin/rails runner "TileCacheWarmJob.perform_now"
+```
+
+This blocks until all z0–z8 tiles are generated (~32 minutes at national scale). Progress is logged to stdout.
 
 ---
 
@@ -180,6 +194,7 @@ docker compose down
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Rails app structure — models, controllers, Stimulus, Turbo patterns |
 | [docs/API.md](docs/API.md) | Endpoint specifications — filter API, tiles, export |
 | [docs/ETL.md](docs/ETL.md) | Data pipeline design — S3 to PostgreSQL import flow |
+| [docs/MAPPING.md](docs/MAPPING.md) | Mapping design information |
 
 ---
 

--- a/app/assets/stylesheets/water_tool.css
+++ b/app/assets/stylesheets/water_tool.css
@@ -664,6 +664,17 @@ ul.stats-list li{
   background-color: #f5f5f5;
 }
 
+#container-ak-hi .region-divider {
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 6px 2px 2px;
+}
+
+#container-ak-hi .territory-btn {
+  color: #666;
+  font-size: .72em;
+}
+
 
 /* TABLE VIEW */
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -257,23 +257,6 @@ export default class extends Controller {
       filter: ["in", "pwsid", ""]
     })
 
-    // ── PWS centroid points (visible at lower zooms) ───────────────────────────
-
-    this.map.addLayer({
-      id: "pws_points",
-      type: "circle",
-      source: "wdt",
-      "source-layer": "pws_points",
-      maxzoom: 8,
-      layout: { visibility: "visible" },
-      paint: {
-        "circle-color": "rgb(78, 163, 36)",
-        "circle-radius": { base: 3, stops: [[2, 2], [7, 5]] },
-        "circle-stroke-color": "#000",
-        "circle-stroke-width": 1,
-        "circle-opacity": 0.7
-      }
-    })
   }
 
   #styleWater() {
@@ -408,19 +391,6 @@ export default class extends Controller {
       })
     })
 
-    // ── pws_points click (lower zooms) → zoom in ─────────────────────────────
-
-    this.map.on("click", "pws_points", (e) => {
-      this.map.flyTo({ center: e.lngLat, zoom: 8.5 })
-    })
-
-    this.map.on("mousemove", "pws_points", () => {
-      this.map.getCanvas().style.cursor = "pointer"
-    })
-
-    this.map.on("mouseleave", "pws_points", () => {
-      this.map.getCanvas().style.cursor = ""
-    })
   }
 
   zoom48() {
@@ -453,7 +423,6 @@ export default class extends Controller {
     if (Object.keys(filters).length === 0) {
       this.map.setFilter("pws", null)
       this.map.setFilter("pws_outline", null)
-      this.map.setFilter("pws_points", null)
       return
     }
 
@@ -476,7 +445,6 @@ export default class extends Controller {
 
       this.map.setFilter("pws", expr)
       this.map.setFilter("pws_outline", expr)
-      this.map.setFilter("pws_points", expr)
     } catch (err) {
       if (err.name !== "AbortError") console.error("[map] filter fetch failed", err)
     }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -20,11 +20,15 @@ export default class extends Controller {
       container: "map",
       style: "mapbox://styles/mapbox/light-v11",
       center: [-97.6, 40.27],
-      zoom: 2,
-      projection: "mercator"
+      zoom: 3,
+      minZoom: 3,
+      projection: "mercator",
+      renderWorldCopies: false
     })
 
     this.map.dragRotate.disable()
+    // Dev convenience: mapDebug.getZoom(), mapDebug.getCenter(), etc. in browser console.
+    if (window.location.hostname === "localhost") window.mapDebug = this.map
     this.hoverPopup = null
     this.hoveredPwsid = null
     this.activeFilterRequest = null
@@ -412,6 +416,27 @@ export default class extends Controller {
     this.map.flyTo({ center: [-157.856, 21.305], zoom: 4.9 })
     this.map.once("idle", () => {
       this.map.flyTo({ zoom: 6, duration: 3600 })
+    })
+  }
+
+  zoomPr() {
+    this.map.flyTo({ center: [-66.590, 18.220], zoom: 5 })
+    this.map.once("idle", () => {
+      this.map.flyTo({ zoom: 8, duration: 3600 })
+    })
+  }
+
+  zoomGu() {
+    this.map.flyTo({ center: [144.794, 13.444], zoom: 7 })
+    this.map.once("idle", () => {
+      this.map.flyTo({ zoom: 10, duration: 3600 })
+    })
+  }
+
+  zoomMp() {
+    this.map.flyTo({ center: [145.674, 15.180], zoom: 7 })
+    this.map.once("idle", () => {
+      this.map.flyTo({ zoom: 9, duration: 3600 })
     })
   }
 

--- a/app/jobs/tile_cache_warm_job.rb
+++ b/app/jobs/tile_cache_warm_job.rb
@@ -1,37 +1,101 @@
 class TileCacheWarmJob < ApplicationJob
   queue_as :default
 
-  # Pre-generate tiles for zoom levels 0–6. Higher zooms are generated
-  # on demand — warming all z0–z8 tiles would be 87k+ coordinates.
-  # Each zoom level runs as a separate job so completed levels aren't
-  # re-done on retry and individual jobs stay short-lived.
-  MAX_WARM_ZOOM = 6
+  MAX_WARM_ZOOM = 8
 
-  def perform(zoom_level = nil)
-    if zoom_level
-      warm_zoom(zoom_level)
-    else
-      (0..MAX_WARM_ZOOM).each { |z| self.class.perform_later(z) }
+  # All [west, south, east, north] bounds must satisfy west < east (no antimeridian wrapping).
+  REGION_BOUNDS = [
+    [-125, 24, -66, 50],  # Continental US
+    [-180, 51, -130, 72],  # Alaska
+    [-161, 18, -154, 23],  # Hawaii
+    [-68, 17, -65, 19],  # Puerto Rico
+    [144, 13, 146, 16]  # Guam + CNMI
+  ].freeze
+
+  def perform
+    total_start = Time.current
+    total_coords = 0
+
+    log("[TileCacheWarm] Starting smart warm for z0-z#{MAX_WARM_ZOOM}")
+
+    (0..MAX_WARM_ZOOM).each do |z|
+      total_coords += warm_zoom(z)
     end
+
+    elapsed = (Time.current - total_start).round(1)
+    log("[TileCacheWarm] Complete - #{total_coords} coordinates warmed in #{elapsed}s")
   end
 
   private
 
   def warm_zoom(z)
-    tile_count = 0
-    grid_size = 2**z
+    started_at = Time.current
+    errors = 0
+    coords = tile_coordinates(z)
+    total = coords.size
 
-    grid_size.times do |x|
-      grid_size.times do |y|
-        TileGenerator.layers.each do |layer|
-          TileGenerator.generate_tile!(layer, z, x, y)
-        rescue => e
-          Rails.logger.error("[TileCacheWarm] #{layer}/z#{z}/#{x}/#{y}: #{e.class} — #{e.message}")
-        end
-        tile_count += 1
+    log("[TileCacheWarm] z#{z}: starting (#{total} coordinates, #{TileGenerator.layers.size} layers each)")
+
+    layers = TileGenerator.layers
+    report_interval = [total / 4, 1].max
+
+    coords.each_with_index do |(x, y), idx|
+      layers.each do |layer|
+        TileGenerator.generate_tile!(layer, z, x, y)
+      rescue => e
+        errors += 1
+        log("[TileCacheWarm] #{layer}/z#{z}/#{x}/#{y}: #{e.class} - #{e.message}", level: :error)
+      end
+
+      if ((idx + 1) % report_interval).zero?
+        pct = (((idx + 1).to_f / total) * 100).round
+        log("[TileCacheWarm] z#{z}: #{pct}% (#{idx + 1}/#{total} coordinates)")
       end
     end
 
-    Rails.logger.info("[TileCacheWarm] z#{z}: warmed #{tile_count} tile coordinate(s)")
+    elapsed = (Time.current - started_at).round(1)
+    error_note = (errors > 0) ? ", #{errors} error(s)" : ""
+    log("[TileCacheWarm] z#{z}: done in #{elapsed}s#{error_note}")
+
+    total
+  end
+
+  # Unions all US region bounding boxes and deduplicates overlapping tile coords.
+  def tile_coordinates(z)
+    seen = Set.new
+    coords = []
+
+    REGION_BOUNDS.each do |west, south, east, north|
+      x_min, x_max, y_min, y_max = bbox_to_tile_range(west, south, east, north, z)
+      (x_min..x_max).each do |x|
+        (y_min..y_max).each do |y|
+          coords << [x, y] if seen.add?([x, y])
+        end
+      end
+    end
+
+    coords
+  end
+
+  def bbox_to_tile_range(west, south, east, north, z)
+    n = 2**z
+    x_min = ((west + 180) / 360.0 * n).floor.clamp(0, n - 1)
+    x_max = ((east + 180) / 360.0 * n).floor.clamp(0, n - 1)
+    y_min = lat_to_tile_y(north, n)
+    y_max = lat_to_tile_y(south, n)
+    [x_min, x_max, y_min, y_max]
+  end
+
+  # Valid for lat in (-85.05, 85.05) — the Web Mercator bounds. Values outside this
+  # range produce NaN/Infinity that clamp silently to 0 or n-1.
+  def lat_to_tile_y(lat_deg, n)
+    lat_rad = lat_deg * Math::PI / 180
+    ((1 - Math.log(Math.tan(lat_rad) + 1.0 / Math.cos(lat_rad)) / Math::PI) / 2 * n).floor.clamp(0, n - 1)
+  end
+
+  def log(msg, level: :info)
+    Rails.logger.public_send(level, msg)
+    $stdout.puts msg
+    $stdout.flush
   end
 end

--- a/app/services/etl/file_importer.rb
+++ b/app/services/etl/file_importer.rb
@@ -14,13 +14,25 @@ module Etl
     end
 
     def call
-      return :skipped unless needs_import?
+      filename = @file_url.split("/").last
 
+      unless needs_import?
+        log("[ETL] #{filename}: skipped (unchanged since last import)")
+        return :skipped
+      end
+
+      log("[ETL] #{filename}: downloading...")
+      started_at = Time.current
       content = download
+      elapsed = (Time.current - started_at).round(1)
+      size_mb = (content.bytesize / 1_048_576.0).round(1)
+      log("[ETL] #{filename}: downloaded #{size_mb} MB in #{elapsed}s")
+
       rows = parse(content)
       validate!(rows)
       import!(rows)
       record_import
+      log("[ETL] #{filename}: import complete")
       :imported
     end
 
@@ -48,6 +60,12 @@ module Etl
 
     def record_import
       DataImport.create!(file_url: @file_url, imported_at: Time.current)
+    end
+
+    def log(msg)
+      Rails.logger.info(msg)
+      $stdout.puts msg
+      $stdout.flush
     end
 
     # Subclasses must implement:

--- a/app/services/tile_generator.rb
+++ b/app/services/tile_generator.rb
@@ -1,5 +1,5 @@
 module TileGenerator
-  LAYERS = %w[pws pws_points places counties states].freeze
+  LAYERS = %w[pws places counties states].freeze
 
   # Simplification tolerances keyed by max zoom level.
   SIMPLIFICATION = [
@@ -104,24 +104,6 @@ module TileGenerator
           JOIN public_water_systems pws ON pws.pwsid = sag.pwsid
           WHERE sag.geom IS NOT NULL
             AND sag.geom && ST_Transform(ST_TileEnvelope(#{z}, #{x}, #{y}), 4326)
-        ) t
-      SQL
-    when "pws_points"
-      <<~SQL.squish
-        SELECT ST_AsMVT(t, 'pws_points', 4096, 'mvtgeom') AS mvt
-        FROM (
-          SELECT
-            ST_AsMVTGeom(
-              ST_Transform(sag.centroid, 3857),
-              ST_TileEnvelope(#{z}, #{x}, #{y}), 4096, 0, false
-            ) AS mvtgeom,
-            pws.pwsid, pws.stusps, pws.pws_name, pws.symbology_field,
-            pws.pop_cat_5, pws.population_served_count, pws.service_connections_count,
-            pws.counties, pws.primacy_agency
-          FROM service_area_geometries sag
-          JOIN public_water_systems pws ON pws.pwsid = sag.pwsid
-          WHERE sag.centroid IS NOT NULL
-            AND sag.centroid && ST_Transform(ST_TileEnvelope(#{z}, #{x}, #{y}), 4326)
         ) t
       SQL
     when "places"

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -91,6 +91,13 @@
        data-action="click->map#zoomAk">AK</a>
     <a href="javascript:void(0);" title="Zoom to Hawaii"
        data-action="click->map#zoomHi">HI</a>
+    <hr class="region-divider">
+    <a href="javascript:void(0);" title="Zoom to Puerto Rico (territory)"
+       data-action="click->map#zoomPr" class="territory-btn">PR</a>
+    <a href="javascript:void(0);" title="Zoom to Guam (territory)"
+       data-action="click->map#zoomGu" class="territory-btn">GU</a>
+    <a href="javascript:void(0);" title="Zoom to Northern Mariana Islands (territory)"
+       data-action="click->map#zoomMp" class="territory-btn">MP</a>
   </div>
 
   <%# Intro tooltip — bottom right of map canvas %>

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+# Benchmarks the key server-side query paths at national scale.
+# Run with: bin/rails runner bin/benchmark
+#
+# Covers the same code paths the server executes per request — no HTTP layer,
+# no browser, no Mapbox. Timings are pure DB + Ruby. Use this to catch slow
+# queries before starting the server and to verify index usage after schema changes.
+#
+# Results are printed to stdout and saved to tmp/benchmarks/<timestamp>.txt
+
+require "benchmark"
+require "fileutils"
+
+SEPARATOR = "-" * 60
+
+output_dir = Rails.root.join("tmp/benchmarks")
+FileUtils.mkdir_p(output_dir)
+output_path = output_dir.join("#{Time.current.strftime("%Y%m%d_%H%M%S")}.txt")
+output = File.open(output_path, "w")
+
+def tee(output, text = "")
+  puts text
+  output.puts text
+end
+
+def section(output, title)
+  tee(output, "\n#{"-" * 60}")
+  tee(output, "  #{title}")
+  tee(output, "-" * 60)
+end
+
+def measure(output, label, &block)
+  result = nil
+  elapsed = Benchmark.realtime { result = block.call }
+  tee(output, format("  %-52s %6.0fms", label, elapsed * 1000))
+  result
+end
+
+tee(output, "\n#{"=" * 60}")
+tee(output, "  Water Data Tool — Query Benchmark")
+tee(output, "  #{PublicWaterSystem.count} systems  |  #{ServiceAreaGeometry.count} geometries")
+tee(output, "  #{Time.current.strftime("%Y-%m-%d %H:%M:%S")}")
+tee(output, "=" * 60)
+
+# ---------------------------------------------------------------------------
+# Seed values — picked live from the DB so the script works on any dataset
+# ---------------------------------------------------------------------------
+sample_county_geoid = CartographicCounty.first&.geoid
+sample_place_geoid  = PlaceSystemCrosswalk.first&.geoid
+largest_state       = PublicWaterSystem.group(:stusps).count.max_by { |_, v| v }&.first
+
+# ---------------------------------------------------------------------------
+# 1. Filter queries — mirrors apply_filters paths in HomeController/StatsController
+# ---------------------------------------------------------------------------
+section(output, "1. Filter queries (apply_filters)")
+
+measure(output, "no filters — count") { PublicWaterSystem.apply_filters({}).count }
+measure(output, "no filters — first page (100 rows)") { PublicWaterSystem.apply_filters({}).limit(100).to_a }
+measure(output, "state filter (#{largest_state})") { PublicWaterSystem.apply_filters({state: largest_state}).count }
+measure(output, "categorical: owner_type + gw_sw_code") { PublicWaterSystem.apply_filters({owner_type: "Private", gw_sw_code: "Groundwater"}).count }
+measure(output, "boolean: is_wholesaler=true") { PublicWaterSystem.apply_filters({is_wholesaler: "true"}).count }
+measure(output, "violations join: health_violations_5yr_min=1") { PublicWaterSystem.apply_filters({health_violations_5yr_min: "1"}).count }
+measure(output, "demographic join: poverty_rate_min=20") { PublicWaterSystem.apply_filters({poverty_rate_min: "20"}).count }
+measure(output, "EJ join: cejst_disadvantaged_pct_min=50") { PublicWaterSystem.apply_filters({cejst_disadvantaged_pct_min: "50"}).count }
+
+if sample_place_geoid
+  measure(output, "place filter (geoid=#{sample_place_geoid})") { PublicWaterSystem.apply_filters({place_geoid: sample_place_geoid}).count }
+end
+
+if sample_county_geoid
+  measure(output, "county spatial filter (geoid=#{sample_county_geoid})") { PublicWaterSystem.apply_filters({county_geoid: sample_county_geoid}).count }
+end
+
+measure(output, "bounds filter (Chicago area)") { PublicWaterSystem.apply_filters({bounds: "-88.5,41.4,-87.2,42.2"}).count }
+
+# ---------------------------------------------------------------------------
+# 2. Map pwsid pluck — HomeController#map path (feeds Mapbox filter expression)
+# ---------------------------------------------------------------------------
+section(output, "2. Map pwsid pluck (HomeController#map)")
+
+no_filter_pwsids = measure(output, "pluck all pwsids — no filter") { PublicWaterSystem.apply_filters({}).pluck(:pwsid) }
+tee(output, "    → #{no_filter_pwsids.size} pwsids returned")
+
+if largest_state
+  state_pwsids = measure(output, "pluck pwsids — state filter (#{largest_state})") { PublicWaterSystem.apply_filters({state: largest_state}).pluck(:pwsid) }
+  tee(output, "    → #{state_pwsids.size} pwsids returned")
+end
+
+# ---------------------------------------------------------------------------
+# 3. Stats/summary aggregation — StatsController#show path
+# ---------------------------------------------------------------------------
+section(output, "3. Stats aggregation (build_summary)")
+
+measure(output, "build_summary — no filter") { PublicWaterSystem.build_summary(PublicWaterSystem.apply_filters({})) }
+measure(output, "build_summary — state filter (#{largest_state})") { PublicWaterSystem.build_summary(PublicWaterSystem.apply_filters({state: largest_state})) }
+measure(output, "build_summary — violations join filter") { PublicWaterSystem.build_summary(PublicWaterSystem.apply_filters({health_violations_5yr_min: "1"})) }
+
+# ---------------------------------------------------------------------------
+# 4. Table page load — HomeController#table path (with preloads)
+# ---------------------------------------------------------------------------
+section(output, "4. Table page load (100 rows with preloads)")
+
+measure(output, "first page, no filter, all associations preloaded") do
+  PublicWaterSystem
+    .apply_filters({})
+    .preload(:violations_summary, :demographic, :environmental_justice,
+      :funding_summary, :watershed_hazard, :boil_water_summary)
+    .order(:pwsid)
+    .limit(100)
+    .to_a
+end
+
+measure(output, "first page, state filter (#{largest_state}), all associations") do
+  PublicWaterSystem
+    .apply_filters({state: largest_state})
+    .preload(:violations_summary, :demographic, :environmental_justice,
+      :funding_summary, :watershed_hazard, :boil_water_summary)
+    .order(:pwsid)
+    .limit(100)
+    .to_a
+end
+
+# ---------------------------------------------------------------------------
+# 5. Tile generation — warm cache retrieval (TilesController#show path)
+#    Measures cache hit speed only. Run bin/benchmark-cold for cold timings.
+# ---------------------------------------------------------------------------
+section(output, "5. Tile generation (warm cache)")
+
+cached_count = TileCache.count
+if cached_count == 0
+  tee(output, "  WARNING: tile_cache is empty — run TileCacheWarmJob first for meaningful results")
+  tee(output, "    bin/rails runner \"TileCacheWarmJob.perform_now\"")
+else
+  tee(output, "  #{cached_count} cached tiles found")
+  [[2, 0, 1], [5, 9, 12], [8, 59, 95]].each do |z, x, y|
+    result = nil
+    warm_ms = (Benchmark.realtime { result = TileGenerator.build_tile(z, x, y) } * 1000).round
+    size_kb = (result.bytesize / 1024.0).round(1)
+    cached = TileCache.where(z: z, x: x, y: y).count
+    status = cached == TileGenerator.layers.size ? "warm" : "partial (#{cached}/#{TileGenerator.layers.size} layers cached)"
+    tee(output, format("  %-52s %6dms  (%s KB)  [%s]", "tile z=#{z} x=#{x} y=#{y}", warm_ms, size_kb, status))
+  end
+end
+
+# ---------------------------------------------------------------------------
+# 6. Full-text search — HomeController#table with search term
+# ---------------------------------------------------------------------------
+section(output, "6. Search query (ILIKE)")
+
+measure(output, "search 'water' — count") do
+  PublicWaterSystem.where(
+    "pws_name ILIKE :q OR pwsid ILIKE :q OR stusps ILIKE :q OR counties ILIKE :q",
+    q: "%water%"
+  ).count
+end
+
+measure(output, "search 'springfield' — count") do
+  PublicWaterSystem.where(
+    "pws_name ILIKE :q OR counties ILIKE :q", q: "%springfield%"
+  ).count
+end
+
+tee(output, "\n#{"-" * 60}")
+tee(output, "  Done. Results saved to #{output_path}")
+tee(output, "-" * 60)
+
+output.close

--- a/bin/benchmark-cold
+++ b/bin/benchmark-cold
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# Measures cold tile generation by clearing the entire tile cache first.
+# Run with: bin/rails runner bin/benchmark-cold
+#
+# WARNING: This script deletes ALL cached tiles before measuring. Run
+# TileCacheWarmJob afterward to restore the warm cache (~32 min at national scale):
+#
+#   bin/rails runner "TileCacheWarmJob.perform_now"
+#
+# Use bin/benchmark (no suffix) for routine regression testing — it never
+# touches the cache.
+
+require "benchmark"
+require "fileutils"
+
+SEPARATOR = "-" * 60
+
+puts "\n#{"!" * 60}"
+puts "  WARNING: THIS SCRIPT DELETES ALL CACHED TILES"
+puts "  #{TileCache.count} tiles currently in cache"
+puts "!"
+puts "  After this runs, restore with:"
+puts "    bin/rails runner \"TileCacheWarmJob.perform_now\""
+puts "#{"!" * 60}\n\n"
+print "  Press Enter to continue, Ctrl-C to abort... "
+$stdin.gets
+
+output_dir = Rails.root.join("tmp/benchmarks")
+FileUtils.mkdir_p(output_dir)
+output_path = output_dir.join("cold_#{Time.current.strftime("%Y%m%d_%H%M%S")}.txt")
+output = File.open(output_path, "w")
+
+def tee(output, text = "")
+  puts text
+  output.puts text
+end
+
+tee(output, "\n#{"=" * 60}")
+tee(output, "  Water Data Tool — Cold Tile Benchmark")
+tee(output, "  #{PublicWaterSystem.count} systems  |  #{ServiceAreaGeometry.count} geometries")
+tee(output, "  #{Time.current.strftime("%Y-%m-%d %H:%M:%S")}")
+tee(output, "=" * 60)
+
+TileCache.delete_all
+tee(output, "\n  Tile cache cleared (#{TileCache.count} tiles remaining)")
+
+tee(output, "\n#{SEPARATOR}")
+tee(output, "  Tile generation (cold → warm)")
+tee(output, SEPARATOR)
+
+[[2, 0, 1], [5, 9, 12], [8, 59, 95]].each do |z, x, y|
+  result = nil
+  cold_ms = (Benchmark.realtime { result = TileGenerator.build_tile(z, x, y) } * 1000).round
+  warm_ms = (Benchmark.realtime { TileGenerator.build_tile(z, x, y) } * 1000).round
+  size_kb = (result.bytesize / 1024.0).round(1)
+  tee(output, format("  %-52s cold: %4dms  warm: %4dms  (%s KB)", "tile z=#{z} x=#{x} y=#{y}", cold_ms, warm_ms, size_kb))
+end
+
+tee(output, "\n#{SEPARATOR}")
+tee(output, "  Done. Results saved to #{output_path}")
+tee(output, SEPARATOR)
+tee(output, "\n  Tile cache now has #{TileCache.count} tiles (only benchmark tiles).")
+tee(output, "  Restore warm cache: bin/rails runner \"TileCacheWarmJob.perform_now\"")
+
+output.close

--- a/docs/MAPPING.md
+++ b/docs/MAPPING.md
@@ -18,17 +18,72 @@ All map data comes from a single vector tile source named `"wdt"`, served by `Ti
 GET /tiles/:z/:x/:y
 ```
 
-The source contains five **source layers** (data channels baked into each tile):
+The source contains four **source layers** (data channels baked into each tile):
 
 | Source layer | Contains | Notes |
 |---|---|---|
 | `pws` | PWS service area polygons | Properties: `pwsid`, `pws_name`, `stusps`, `symbology_field`, `population_served_count`, `service_connections_count` |
-| `pws_points` | PWS centroid points | Same properties as `pws`; ensures systems are visible at low zoom before polygons are large enough to click |
 | `places` | Census place boundaries | Properties: `geoid`, `name` |
 | `counties` | County boundaries | Properties: `geoid`, `name` |
 | `states` | State boundaries | Properties: `geoid`, `stusps` |
 
-Tiles are generated on-demand by PostGIS (`ST_AsMVT`) and cached in the `tile_cache` table. See `docs/ETL.md` and `ARCHITECTURE.md` for tile caching and invalidation.
+---
+
+## Tile Caching
+
+Tiles are generated on-demand by PostGIS (`ST_AsMVT`) and cached in the `tile_cache` database table as binary blobs. The cache is **global and shared across all users** — the first user to request any tile pays the generation cost; every subsequent user gets the cached version instantly regardless of who originally generated it.
+
+### Find-or-create per request
+
+`TileGenerator.build_tile(z, x, y)` checks the cache for all 4 layers at once. Any layers already cached are returned immediately; missing layers are generated, persisted, and returned. A partially-cached tile coordinate (e.g. 3 of 4 layers present) only generates the missing layers.
+
+### Cache lifecycle
+
+1. **Cold** — tile has never been requested; PostGIS generates it from `service_area_geometries` (slow, especially at low zoom where many polygons are included)
+2. **Warm** — tile exists in `tile_cache`; returned as a simple DB lookup (fast)
+3. **Invalidated** — ETL runs and calls `bust_tile_cache`, which truncates the entire `tile_cache` table; all tiles revert to cold
+
+The ETL always wipes the full table (not selectively) because tiles embed non-geometry attributes (system names, categories, etc.) that can change from CSV-only imports.
+
+### Pre-warming (TileCacheWarmJob)
+
+After each ETL run, `TileCacheWarmJob` pre-generates tiles for z0–z8 using US region bounding boxes (continental US, AK, HI, PR, Guam+CNMI). This skips empty ocean and land tiles entirely and covers through city/district zoom — the level where users first interact with individual water utility polygons. z9+ tiles generate on-demand (fast, small area).
+
+The warm job takes ~32 minutes at national scale (~44k systems). See `scratch/performance_work.md` for full timing data.
+
+### Zoom level tile counts
+
+Warming stops at z8 because z9+ on-demand generation is fast (each tile covers a small area with few polygons). The smart bounding-box approach uses far fewer coordinates than a blind full-grid warm:
+
+| Zoom | US-only coords | Full grid | Reduction | × 4 layers |
+|------|---------------|-----------|-----------|------------|
+| z0 | 1 | 1 | 0% | 4 |
+| z1 | 2 | 4 | 50% | 8 |
+| z2 | 4 | 16 | 75% | 16 |
+| z3 | 9 | 64 | 86% | 36 |
+| z4 | 23 | 256 | 91% | 92 |
+| z5 | 59 | 1,024 | 94% | 236 |
+| z6 | 172 | 4,096 | 96% | 688 |
+| z7 | 608 | 16,384 | 96% | 2,432 |
+| z8 | 2,335 | 65,536 | 96% | 9,340 |
+| **z0–z8 total** | **3,213** | **349,525** | **96.5%** | **~12,852 ops** |
+| z9+ | — | millions | — | impractical to warm |
+
+### Geometry simplification by zoom
+
+Tile generation applies `ST_SimplifyPreserveTopology` with a tolerance that decreases as zoom increases — coarser at low zoom (national view), finer at high zoom (street level):
+
+| Max zoom | Tolerance |
+|----------|-----------|
+| z≤4 | 0.05 |
+| z5 | 0.01 |
+| z6 | 0.005 |
+| z7 | 0.001 |
+| z8 | 0.0005 |
+| z9 | 0.0001 |
+| z10 | 0.00005 |
+| z11 | 0.00001 |
+| z12+ | 0 (no simplification — raw geometry) |
 
 ---
 
@@ -72,13 +127,11 @@ These layers render the actual drinking water system data.
 | `pws` | `pws` | fill | Always | Green fill (`rgb(78,163,36)`), 20% opacity, black outline | Main polygon fill. **[M10 — not built]** Will be filtered to matching pwsids when filters are active |
 | `pws_outline` | `pws` | line | minzoom 8 | Black, 1.5–3.5px (zoom-interpolated) | Thin border at street-level zoom. **[M10 — not built]** Filtered same as `pws` |
 | `pws_hover` | `pws` | line | On hover only | Black, 2–4.5px (zoom-interpolated) | Thicker border on the hovered system; controlled by `setFilter` |
-| `pws_points` | `pws_points` | circle | maxzoom 8 | Green circle, radius 2–5px by zoom, black 1px stroke, 70% opacity | Centroid dots shown at national/state zoom before polygons are visible. **[M10 — not built]** Filtered same as `pws` |
 | `selected_pws` | `pws` | line | On click only | Red (`#f00`), 2px | Highlights the clicked system; `visibility: none` until a system is clicked |
 
 **Zoom logic:**
-- Below zoom 8: `pws_points` circles are shown; polygons render but are tiny
-- Above zoom 8: `pws_outline` appears; `pws_points` are hidden
-- Clicking a polygon below zoom 8 triggers a `flyTo` to zoom 8.5 instead of opening a popup
+- Below zoom 8: polygon clicks trigger a `flyTo` to zoom 8.5 instead of opening a popup
+- Above zoom 8: `pws_outline` appears; polygon clicks open popups
 
 ---
 
@@ -135,15 +188,6 @@ When the click popup is closed: `selected_pws` layer hidden, popup reference cle
 
 ---
 
-### PWS point click (low zoom)
-
-| Event | Result |
-|---|---|
-| Click `pws_points` | `flyTo` center at click location, zoom 8.5 |
-| Hover `pws_points` | Cursor → pointer |
-
----
-
 ### Geocoder (map search)
 
 The geocoder is rendered into the filter bar (`#geocoder-li`) rather than as a floating map control. When a result is selected, the map flies to it at a zoom level determined by place type:
@@ -166,6 +210,9 @@ These are called by nav/button elements outside the map canvas:
 | `zoom48()` | Clears geocoder input; flies to continental US center (`-97.6, 40.27`, zoom 3.5) |
 | `zoomAk()` | Flies to Alaska (`-149.504, 61.342`, zoom ~5) |
 | `zoomHi()` | Flies to Hawaii (`-157.856, 21.305`, zoom ~6) |
+| `zoomPr()` | Flies to Puerto Rico (`-66.590, 18.220`, zoom 8) |
+| `zoomGu()` | Flies to Guam (`144.794, 13.444`, zoom 10) |
+| `zoomMp()` | Flies to Northern Mariana Islands (`145.674, 15.180`, zoom 9) |
 
 ---
 
@@ -183,7 +230,6 @@ These are called by nav/button elements outside the map canvas:
 | `pws` | All systems visible | **[M10 — not built]** filtered to matching pwsids on filter change |
 | `pws_hover` | Hidden (empty filter) | Mouse enters/leaves a PWS polygon (zoom ≥ 5) |
 | `pws_outline` | Visible at zoom ≥ 8 | Zoom; **[M10 — not built]** filtered same as `pws` |
-| `pws_points` | Visible at zoom < 8 | Zoom; **[M10 — not built]** filtered same as `pws` |
 | `selected_pws` | Hidden (`visibility: none`) | System clicked (shown); popup closed (hidden) |
 
 ---
@@ -192,7 +238,7 @@ These are called by nav/button elements outside the map canvas:
 
 M10 adds filter→map sync. After M10, when the user applies filters:
 
-- `pws`, `pws_outline`, and `pws_points` will each have a Mapbox GL filter expression applied: `["in", "pwsid", ...matchingIds]`
+- `pws` and `pws_outline` will each have a Mapbox GL filter expression applied: `["in", "pwsid", ...matchingIds]`
 - Non-matching systems disappear from the map
 - When all filters are cleared: filter expressions reset to `null` (show all)
 - On page load with filter params in the URL: filter is applied immediately after tiles load
@@ -212,7 +258,7 @@ This feature is not in the current roadmap. It depends on the demographic histog
 ## Glossary
 
 **Centroid**
-The geometric center point of a polygon. Used here as a fallback representation for PWS service areas at low zoom levels — when a polygon is too small to see or click, a centroid dot (`pws_points`) is shown instead.
+The geometric center point of a polygon. Stored in `service_area_geometries.centroid` and used internally (e.g. bounding box filtering in the warm job). Not rendered on the map.
 
 **Choropleth**
 A map where areas are shaded or colored according to a data variable (e.g. median household income). The legacy app supported this via a "Continuous display" toggle on demographic sliders. Not yet built in V2.
@@ -239,7 +285,7 @@ A Mapbox GL layer type that renders a stroke along the edge of a polygon or alon
 The JavaScript library used to render the interactive map. It draws map tiles using WebGL and exposes an API for adding layers, handling events, and applying filters/styles dynamically.
 
 **minzoom / maxzoom**
-Per-layer zoom thresholds. A layer with `minzoom: 8` is invisible below zoom level 8. A layer with `maxzoom: 8` is invisible at zoom level 8 and above. Used here to swap between centroid dots (`pws_points`, maxzoom 8) and polygon outlines (`pws_outline`, minzoom 8).
+Per-layer zoom thresholds. A layer with `minzoom: 8` is invisible below zoom level 8. A layer with `maxzoom: 8` is invisible at zoom level 8 and above. Used here for `pws_outline` (minzoom 8) and `places` (minzoom 8).
 
 **MVT (Mapbox Vector Tile)**
 A binary tile format (protobuf) used to deliver geographic data to the browser in chunks. The server generates tiles on-demand using PostGIS's `ST_AsMVT` function and caches them in the `tile_cache` table. The browser reassembles them into a continuous map.
@@ -257,10 +303,10 @@ A drinking water utility serving the public. The central data entity in this app
 The geographic boundary of a PWS — the area it is licensed to serve. Stored as a PostGIS polygon in the `service_area_geometries` table and served via the `pws` source layer in vector tiles.
 
 **Source layer**
-A named data channel within a vector tile. A single tile request (`/tiles/z/x/y`) returns one binary blob containing multiple source layers (`pws`, `pws_points`, `states`, etc.). Mapbox GL map layers each read from one source layer.
+A named data channel within a vector tile. A single tile request (`/tiles/z/x/y`) returns one binary blob containing multiple source layers (`pws`, `places`, `counties`, `states`). Mapbox GL map layers each read from one source layer.
 
 **Vector tile**
 See MVT. A tile that contains geographic feature data (points, lines, polygons) and their properties, as opposed to a raster tile which contains pre-rendered pixel imagery.
 
 **Zoom level**
-An integer (roughly 0–22) representing how far the map is zoomed in. Zoom 0 shows the whole world; zoom 22 shows individual buildings. Key thresholds in this app: zoom 5 (PWS hover activates), zoom 8 (polygon clicks open popups; `pws_outline` appears; `pws_points` disappear).
+An integer (roughly 0–22) representing how far the map is zoomed in. Zoom 0 shows the whole world; zoom 22 shows individual buildings. Key thresholds in this app: zoom 3 (minimum zoom — restricted to North America view), zoom 5 (PWS hover activates), zoom 8 (polygon clicks open popups; `pws_outline` appears).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,6 +12,8 @@ These are not milestones — see ROADMAP.md for planned feature work.
 3. **ETL Field Mapping Validation** — Build post-import audit specs that assert expected distinct values per filterable column, catching silent data quality bugs before they surface as broken filters
 
 - ~~Dev Seed Data — Filter Coverage Gaps (add Ohio or similar to cover wholesaler/school filters)~~ Default seed now includes OH, CO, PR alongside VT + RI — verify `is_wholesaler` and `is_school_or_daycare` counts after first seed run
+- Map — State click should update stats bar with counts for that state. Legacy app filtered the stats panel to the clicked state even without any other filters active. V2 draws the border outline on click but does not update stats — clicking a state on the map feels like it does nothing data-wise. Fix: clicking a state should apply a state boundary filter (or trigger a stats refresh scoped to that state).
+- Add Lograge gem to help silence noisy logs
 - Filter UI — `has-filter` green highlight on active filter buttons
 - Filter UI — Verify badge counts match legacy behavior
 - Filter UI — More dropdown expand/collapse sub-filters (violations + watershed hazards)
@@ -26,6 +28,7 @@ These are not milestones — see ROADMAP.md for planned feature work.
 - Frontend Modernization — Activate Tailwind and migrate custom CSS *(on hold)*
 - Export UX — Test CSV and GeoJSON downloads against a large dataset (e.g. full national or a large state). If generation takes more than ~2–3 seconds, add a spinner/disabled-button state to `export_controller.js` to indicate work in progress. The legacy app had no spinner; this is only needed if server-side generation time is noticeable.
 - Map Filter Scale — The current filter→map approach fetches matching pwsids from `GET /map` and spreads them into a Mapbox GL `["in", "pwsid", ...]` filter expression. This works well at state scale but may hit expression size limits or cause noticeable latency at national scale (tens of thousands of systems). If that proves to be the case, the architectural fix is to pass filter params directly into the tile URL so `TilesController` applies `apply_filters` during MVT generation — eliminating the pwsid fetch entirely. That approach would require tile cache keys to include filter params (or bypass the cache for filtered requests).
+- ~~Tile Cache Warm Depth — `TileCacheWarmJob` now warms z0–z8 using US region bounding boxes (continental US, AK, HI, PR, Guam+CNMI), skipping empty ocean/land tiles. 96.5% reduction vs blind z0–z8 approach (3,213 coords vs ~349k). z9 generates on-demand (fast). See `scratch/performance_work.md` for full metrics.~~
 - Other — Ensure Mapbox token is not exposed in browser devtools
 - Other — Add pending migration warning on console/server/spec startup
 - Other — Add `simplecov` and `lefthook` gems

--- a/spec/jobs/tile_cache_warm_job_spec.rb
+++ b/spec/jobs/tile_cache_warm_job_spec.rb
@@ -1,50 +1,60 @@
 require "rails_helper"
 
 RSpec.describe TileCacheWarmJob, type: :job do
-  describe "#perform without a zoom_level argument" do
-    it "enqueues a separate job for each zoom level 0 through MAX_WARM_ZOOM" do
-      expect {
-        described_class.perform_now
-      }.to have_enqueued_job(described_class)
-        .exactly(described_class::MAX_WARM_ZOOM + 1).times
+  before do
+    allow(TileGenerator).to receive(:generate_tile!)
+    allow($stdout).to receive(:puts)
+    allow($stdout).to receive(:flush)
+  end
+
+  describe "#perform" do
+    it "calls generate_tile! for each layer at every zoom level" do
+      # Stub tile_coordinates to return one coord per zoom to keep the test fast.
+      # The coordinate math is covered by the #tile_coordinates unit tests below.
+      allow_any_instance_of(described_class).to receive(:tile_coordinates).and_return([[0, 0]])
+
+      described_class.perform_now
+
+      TileGenerator.layers.each do |layer|
+        expect(TileGenerator).to have_received(:generate_tile!)
+          .with(layer, anything, 0, 0).at_least(:once)
+      end
+    end
+
+    it "continues warming remaining tiles when one layer raises" do
+      call_count = 0
+      allow(TileGenerator).to receive(:generate_tile!) { |layer, z, x, y|
+        raise "boom" if z == 1 && x == 0 && y == 0 && layer == "pws"
+        call_count += 1
+      }
+
+      expect { described_class.perform_now }.not_to raise_error
+      expect(call_count).to be > 0
     end
   end
 
-  describe "#perform with a zoom_level argument" do
-    it "generates tiles for every coordinate at the given zoom level" do
-      call_count = 0
-      allow(TileGenerator).to receive(:generate_tile!) { call_count += 1 }
+  describe "#tile_coordinates" do
+    subject(:job) { described_class.new }
 
-      described_class.new.perform(2)
-
-      # z2: 4x4 grid = 16 coords × 5 layers = 80 calls
-      expect(call_count).to eq(16 * 5)
+    it "returns far fewer coordinates than the full grid at high zoom" do
+      full_grid_z7 = (2**7)**2  # 16,384 — the blind approach
+      us_only_z7 = job.send(:tile_coordinates, 7).size
+      expect(us_only_z7).to be < full_grid_z7 / 10
     end
 
-    it "calls generate_tile! (skip-cache variant) for each layer" do
-      layers_called = []
-      allow(TileGenerator).to receive(:generate_tile!) { |layer, _z, _x, _y|
-        layers_called << layer
-      }
+    it "includes corner tiles for all defined regions at z7" do
+      coords = job.send(:tile_coordinates, 7)
 
-      described_class.new.perform(0)
-
-      expect(layers_called).to match_array(TileGenerator.layers)
+      described_class::REGION_BOUNDS.each do |west, south, east, north|
+        x_min, x_max, y_min, y_max = job.send(:bbox_to_tile_range, west, south, east, north, 7)
+        expect(coords).to include([x_min, y_min]), "expected NW corner for bbox [#{west},#{south},#{east},#{north}]"
+        expect(coords).to include([x_max, y_max]), "expected SE corner for bbox [#{west},#{south},#{east},#{north}]"
+      end
     end
 
-    it "continues generating remaining layers when one layer fails" do
-      call_args = []
-      allow(TileGenerator).to receive(:generate_tile!) { |layer, z, x, y|
-        raise "boom" if x == 0 && y == 0 && layer == "pws"
-        call_args << [layer, z, x, y]
-      }
-
-      expect { described_class.new.perform(1) }.not_to raise_error
-
-      # z1 = 2x2 grid = 4 coords × 5 layers = 20 total calls.
-      # Only pws at (0,0) fails; the other 4 layers at (0,0) succeed.
-      # So 20 - 1 = 19 successful calls.
-      expect(call_args.length).to eq(19)
+    it "produces no duplicate coordinates" do
+      coords = job.send(:tile_coordinates, 7)
+      expect(coords.uniq.size).to eq(coords.size)
     end
   end
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -81,13 +81,13 @@ RSpec.describe "Home", type: :request do
     end
 
     it "returns only a pwsids key — no other fields" do
-      create(:public_water_system)
+      pws = create(:public_water_system)
 
       get map_path
 
       json = response.parsed_body
       expect(json.keys).to eq(["pwsids"])
-      expect(json["pwsids"].first).to be_a(String)
+      expect(json["pwsids"].first).to eq(pws.pwsid)
     end
   end
 

--- a/spec/requests/tiles_spec.rb
+++ b/spec/requests/tiles_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Tiles", type: :request do
   let(:y) { 12 }
 
   describe "GET /tiles/:z/:x/:y" do
-    context "when all 5 layers are cached" do
-      let(:layers) { %w[pws pws_points places counties states] }
+    context "when all #{TileGenerator::LAYERS.size} layers are cached" do
+      let(:layers) { TileGenerator::LAYERS }
       let(:mvt_data) { "\x1a\x10tile_data".b }
 
       before do

--- a/spec/services/etl/file_importer_spec.rb
+++ b/spec/services/etl/file_importer_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Etl::FileImporter do
   let(:last_updated) { 1.day.ago }
   let(:importer) { importer_class.new(file_url: file_url, last_updated: last_updated) }
 
+  before do
+    allow($stdout).to receive(:puts)
+    allow($stdout).to receive(:flush)
+  end
+
   describe "#call" do
     context "when no prior import exists for this file_url" do
       it "downloads and imports the file, returning :imported" do

--- a/spec/services/etl/importers/epa_sabs_geoms_spec.rb
+++ b/spec/services/etl/importers/epa_sabs_geoms_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Etl::Importers::EpaSabsGeoms do
     end
 
     it "stores raw GeoJSON geometry string for SQL import" do
-      expect(rows.first[:geom_json]).to be_a(String)
       parsed = JSON.parse(rows.first[:geom_json])
       expect(parsed["type"]).to eq("MultiPolygon")
+      expect(parsed["coordinates"]).to be_an(Array)
     end
   end
 

--- a/spec/services/tile_generator_spec.rb
+++ b/spec/services/tile_generator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe TileGenerator do
   let(:y) { 12 }
 
   describe ".layers" do
-    it "returns the five expected layer names" do
-      expect(described_class.layers).to eq(%w[pws pws_points places counties states])
+    it "returns the four expected layer names" do
+      expect(described_class.layers).to eq(%w[pws places counties states])
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe TileGenerator do
   end
 
   describe ".build_tile" do
-    context "when all 5 layers are cached" do
+    context "when all layers are cached" do
       let(:mvt_data) { "\x1a\x10tile_data".b }
 
       before do
@@ -84,7 +84,7 @@ RSpec.describe TileGenerator do
 
       it "returns concatenated MVT binary from all cached layers" do
         result = described_class.build_tile(z, x, y)
-        expect(result.bytesize).to eq(mvt_data.bytesize * 5)
+        expect(result.bytesize).to eq(mvt_data.bytesize * 4)
       end
     end
 

--- a/spec/services/tile_generator_spec.rb
+++ b/spec/services/tile_generator_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe TileGenerator do
     end
 
     context "when no cached tile exists (empty database)" do
-      it "returns a binary string" do
+      it "returns the generated MVT binary and caches it" do
         result = described_class.generate_tile("pws", z, x, y)
-        expect(result).to be_a(String)
-        expect(result.encoding).to eq(Encoding::ASCII_8BIT)
+        cached = TileCache.find_by!(layer: "pws", z: z, x: x, y: y)
+        expect(result).to eq(cached.mvt)
       end
 
       it "persists the generated tile to the cache" do
@@ -58,10 +58,9 @@ RSpec.describe TileGenerator do
 
   describe ".generate_tile!" do
     context "when no cached tile exists (empty database)" do
-      it "returns a binary string without checking the cache" do
+      it "returns the generated MVT binary without checking the cache" do
         expect(TileCache).not_to receive(:find_by)
         result = described_class.generate_tile!("pws", z, x, y)
-        expect(result).to be_a(String)
         expect(result.encoding).to eq(Encoding::ASCII_8BIT)
       end
 
@@ -89,10 +88,12 @@ RSpec.describe TileGenerator do
     end
 
     context "when no tiles are cached" do
-      it "returns a binary string" do
+      it "returns concatenated MVT matching the sum of all generated layer tiles" do
         result = described_class.build_tile(z, x, y)
-        expect(result).to be_a(String)
-        expect(result.encoding).to eq(Encoding::ASCII_8BIT)
+        expected_size = described_class.layers.sum { |layer|
+          TileCache.find_by!(layer: layer, z: z, x: x, y: y).mvt.bytesize
+        }
+        expect(result.bytesize).to eq(expected_size)
       end
     end
   end


### PR DESCRIPTION
## Summary

Performance and map quality improvements for the national-scale dataset. Replaces the blind tile cache warming strategy with a US bounding-box approach that covers two more zoom levels while using fewer total tile operations. Also removes a noisy centroid dot layer, tightens map zoom behavior, and adds territory navigation.

---

## Changes

### Tile cache warming — smart z0–z8 with US bounding boxes

The old warm job generated tiles for every coordinate in the global grid for z0–z6, including empty ocean and land tiles. The new approach uses US region bounding boxes (continental US, AK, HI, PR, Guam+CNMI) to skip tiles with no PWS data, and extends warm coverage through z8.

- Warm coverage extended from z6 (large metro region zoom) to z8 (city/district zoom) — the level where users first see and interact with individual water utility polygons
- `MAX_WARM_ZOOM = 8` with bounding box filtering; z9+ generates on-demand (fast — small area, few polygons per tile)
- Fixed `perform_now` behavior: the previous implementation used `perform_later` per zoom level, which silently dropped jobs when run via `bin/rails runner` (no persistent worker); now runs all zoom levels synchronously inline
- Added live `$stdout` progress logging alongside `Rails.logger` so warm job progress is visible in the terminal

### `pws_points` layer removed (~20% tile cost reduction)

The centroid dot layer rendered green circles at low zoom. It was added in V2 but was not present in the legacy app, produced visual clutter over dense metro areas, and added a full extra layer (20%) to every tile generation and cache operation. Removed from `TileGenerator::LAYERS`, the SQL case block, and all map event handlers and filter calls.

### Map UX — zoom restrictions and territory navigation

- `renderWorldCopies: false` — prevents the map from rendering duplicate world copies when zoomed fully out
- `minZoom: 3` — restricts zoom-out to a North America view (previously allowed zooming out to see the whole world multiple times)
- Territory navigation buttons added for PR, GU, and MP with a visual divider separating them from state shortcuts. VI and AS have no PWS data and were intentionally excluded. All three territory zoom methods use the same two-step cinematic animation as AK and HI.

### ETL file importer progress logging

`FileImporter#call` now logs download progress, file size, elapsed time, and import completion to both `Rails.logger` and `$stdout` — making long-running ETL imports visible when invoked via `bin/rails runner`.

### Benchmarking tools

- `bin/benchmark` — safe to run at any time; measures filter queries, map pwsid pluck, stats aggregation, table page load, warm tile retrieval, and search. Never modifies the cache.
- `bin/benchmark-cold` — separate script for cold tile baseline measurements; requires explicit confirmation before wiping the tile cache and reminds you to re-run the warm job afterward.

---

## Metrics

### Smart z0–z8 vs old blind z0–z6

The most important result: **the new approach uses fewer tile operations than the old one while covering two more zoom levels.**

| Approach | Zoom coverage | Tile ops | Deepest warm zoom | Est. total time |
|----------|--------------|----------|-------------------|----------------|
| Old: blind z0–z6 | State-level view | ~21,844 | z6 — large metro region | ~12–19 min |
| **New: smart z0–z8** | **City/district view** | **~12,872** | **z8 — city/district** | **~32 min** |

The old approach warmed through z6 but generated 4,096 tile coordinates at that zoom — most of them empty ocean. The new approach uses 172 z6 coordinates (US-only) and extends through z8 with only 2,335 coordinates at that level. **96.5% reduction vs a naive full-grid z0–z9 approach** (3,213 coords vs 349,525).

### Why z8 is the sweet spot

| Zoom | Visual scale | Warmed? |
|------|-------------|---------|
| z6   | Large metro region | ✓ |
| z7   | Metro area | ✓ |
| z8   | City / district | ✓ ← warm floor |
| z9   | Neighborhood | on-demand |
| z10+ | Street-level | on-demand |

### Observed warm job timings (national dataset, ~44k systems)

| Zoom | Coords | Time | Per-coord |
|------|--------|------|-----------|
| z5 | 59 | 80.8s | 1.37s |
| z6 | 172 | 148.8s | 0.87s |
| z7 | 608 | 367.6s | 0.60s |
| z8 | 2,335 | 1,092.6s | 0.47s |
| **z0–z8 total** | **3,213** | **~1,940s** | **~32 min** |

Per-coord cost decreases at higher zooms — each tile covers a smaller area with fewer PWS geometries to aggregate.

z9 cold generation measured at 234ms. Pre-warming z9 would add ~53 minutes to the warm job for a quarter-second on-demand cost — not worth it.  

### Benchmark results — national dataset, 44,642 systems

**Tile generation (post-warm-job):**

| Tile | Cold | Warm | Speedup |
|------|------|------|---------|
| z=2 | 10,141ms | 47ms | **216×** |
| z=5 | 6,178ms | 26ms | **238×** |
| z=8 | 430ms | 4ms | **108×** |

The z=2 cold cost (10s) is not a query efficiency problem — EXPLAIN ANALYZE shows the bottleneck is `ST_AsMVT` aggregating ~24k geometries across 3 parallel workers. No missing index. This is why pre-warming exists: you pay the cost once, not per user. z=8 cold at 430ms confirms z9 on-demand is acceptable.

**Filter queries at national scale:**

| Query | Time |
|-------|------|
| No filter — count | 0ms |
| State filter (TX) | 2ms |
| Violations join | 30ms |
| EJ join (CEJST) | 35ms |
| Bounds filter (Chicago area) | 32ms |
| PWSID pluck — all 44k | 37ms |
| build_summary — no filter | 131ms |

---

## Notes for reviewers

- The warm job is destructive to the tile cache when run (it generates and upserts). Running `bin/benchmark-cold` also wipes the cache — the split into two scripts was specifically to prevent accidental cache destruction during routine benchmarking.
- `scratch/performance_work.md` contains the full session notes including the EXPLAIN ANALYZE breakdown, storage size measurements, and the reasoning behind all numerical constants.
- The `bin/benchmark` warm tile section will warn (not fail) if the cache is empty, prompting you to run the warm job first.
