### PR TITLE
[Feat] Add Lograge gem for cleaner logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+gem "lograge"
+gem "lograge-sql"
+
 group :development, :test do
   # Load environment variables from .env [https://github.com/bkeepers/dotenv]
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,14 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    lograge-sql (2.6.1)
+      activerecord (>= 5, < 8.2)
+      lograge (~> 0.11)
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -296,6 +304,8 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rgeo (3.1.0)
     rgeo-activerecord (8.1.0)
       activerecord (>= 8.1, < 8.2)
@@ -453,6 +463,8 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   kamal
+  lograge
+  lograge-sql
   pagy (~> 43.5)
   pg (~> 1.1)
   propshaft

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -5,5 +5,5 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cv,
-  :mvt # Binary Mapbox Vector Tile data; filtered to prevent massive binary strings from bloating logs 
+  :mvt # Binary Mapbox Vector Tile data; filtered to prevent massive binary strings from bloating logs
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,5 +4,6 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cv,
+  :mvt # Binary Mapbox Vector Tile data; filtered to prevent massive binary strings from bloating logs 
 ]

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,31 @@
+require "lograge/sql/extension"
+
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.action_view.logger = nil
+
+  config.lograge.formatter = Class.new do
+    def call(data)
+      data.except(:format, :view, :allocations)
+          .map { |k, v| "#{k}=#{v}" }
+          .join(" ")
+    end
+  end.new
+
+  config.lograge_sql.extract_event = proc do |event|
+    next unless event.payload[:name].present?
+    { name: event.payload[:name], duration: event.duration.to_f.round(2) }
+  end
+
+  config.lograge_sql.formatter = proc do |queries|
+    queries.compact.map { |q| "#{q[:name]} (#{q[:duration]}ms)" }.join(", ")
+  end
+
+  config.lograge.custom_options = lambda do |event|
+    {
+      time: Time.current.iso8601,
+      request_id: event.payload[:headers]["action_dispatch.request_id"],
+      params: event.payload[:params].except("controller", "action", "format", "mvt").presence
+    }.compact
+  end
+end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -7,14 +7,14 @@ Rails.application.configure do
   config.lograge.formatter = Class.new do
     def call(data)
       data.except(:format, :view, :allocations)
-          .map { |k, v| "#{k}=#{v}" }
-          .join(" ")
+        .map { |k, v| "#{k}=#{v}" }
+        .join(" ")
     end
   end.new
 
   config.lograge_sql.extract_event = proc do |event|
     next unless event.payload[:name].present?
-    { name: event.payload[:name], duration: event.duration.to_f.round(2) }
+    {name: event.payload[:name], duration: event.duration.to_f.round(2)}
   end
 
   config.lograge_sql.formatter = proc do |queries|

--- a/docs/MAPPING.md
+++ b/docs/MAPPING.md
@@ -255,6 +255,37 @@ This feature is not in the current roadmap. It depends on the demographic histog
 
 ---
 
+## Dev Console (localhost only)
+
+`mapDebug` is assigned to the Mapbox GL map instance when running on `localhost` (see `map_controller.js`). It is `undefined` in production.
+
+### Useful commands
+
+| Command | What it returns |
+|---|---|
+| `mapDebug.getZoom()` | Current zoom level (once) |
+| `mapDebug.getCenter()` | Current map center `{lng, lat}` (once) |
+| `mapDebug.getStyle().layers` | Array of all active Mapbox GL layers and their current state |
+| `mapDebug.queryRenderedFeatures()` | All features visible in the current viewport |
+
+### Continuous tracking
+
+Register a listener to log on every zoom change:
+
+```js
+mapDebug.on('zoom', () => console.log(mapDebug.getZoom()))
+```
+
+Same pattern works for any map event (`move`, `moveend`, `click`, etc.):
+
+```js
+mapDebug.on('move', () => console.log(mapDebug.getCenter()))
+```
+
+These listeners persist for the browser session. Reload the page to clear them.
+
+---
+
 ## Glossary
 
 **Centroid**


### PR DESCRIPTION
## Summary
 
### Logging
 - Adds [Lograge](https://github.com/roidrage/lograge) and [lograge-sql](https://github.com/iMacTia/lograge-sql) gems - widely-used Rails logging libraries that replaces Rails' multi-line request logs with a single, structured key=value line per request, including SQL query summaries.
  - Configures [lograge.rb](config/initializers/lograge.rb) - emits timestamp, request ID, and filtered params per request; suppresses noisy ActionView render logs entirely.
  - Filters MVT binary data from logs [filter_parameter_logging.rb](filter_parameter_logging.rb) - Mapbox Vector Tile payloads were bloating logs with large binary strings on tile upserts, so `:mvt` is now redacted the same way passwords and tokens are.


### Dev Tools
  - Documents the mapDebug dev console tool (docs/MAPPING.md) — mapDebug exposes the Mapbox GL map instance in localhost only; the new section covers one-shot commands (getZoom, getCenter, etc.) and how to set up continuous zoom/position tracking via event listeners.





----

### Logging

What our logs now look like:
<img width="1711" height="584" alt="Screenshot 2026-04-27 at 11 18 11 AM" src="https://github.com/user-attachments/assets/ed6c1627-b030-47bd-b31e-604f14766ea2" />

At Zoom z8, we are still loading files from the TileCache
<img width="2838" height="1115" alt="Screenshot 2026-04-27 at 11 21 24 AM" src="https://github.com/user-attachments/assets/fd63157a-77de-4fa6-9d50-991511e793c6" />

Once we get int z9 or greater, we create new tiles in the TileCache _(as seen by the upsert call)_
<img width="2752" height="858" alt="Screenshot 2026-04-27 at 11 21 50 AM" src="https://github.com/user-attachments/assets/b0d1a5a5-e9cf-4763-b40e-99f79a4a59ff" />

Before adding Lograge and configuring our output, logs were noisy with upserts and looked like this:
<img width="1695" height="1044" alt="Screenshot 2026-04-27 at 11 23 34 AM" src="https://github.com/user-attachments/assets/fb201d00-834c-434b-8c5a-b75ea2780547" />

-----

### Console Dev Tools

View the current zoom level:
<img width="460" height="360" alt="Screenshot 2026-04-27 at 11 25 12 AM" src="https://github.com/user-attachments/assets/3d4388a9-f7ac-4dc9-842f-39e2c0965452" />

View the current zoom level as you move around the map:
<img width="1039" height="344" alt="Screenshot 2026-04-27 at 11 25 53 AM" src="https://github.com/user-attachments/assets/0b3c2be5-b818-41dc-8912-37212672d476" />
