### PR TITLE
[Fix] Move to Streamable Geoms

### DIFF
--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -178,7 +178,7 @@ jobs:
             {"name":"SOLID_QUEUE_IN_PUMA", "value":"true"},
             {"name":"HTTP_PORT",           "value":"3000"},
             {"name":"TARGET_PORT",         "value":"3001"},
-            {"name":"ETL_SOURCE_URL",      "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/test-staged"}
+            {"name":"ETL_SOURCE_URL",      "value":"${{ vars.ETL_SOURCE_URL }}"}
           ]'
 
           docker run --rm \

--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -177,7 +177,8 @@ jobs:
             {"name":"RAILS_LOG_TO_STDOUT", "value":"1"},
             {"name":"SOLID_QUEUE_IN_PUMA", "value":"true"},
             {"name":"HTTP_PORT",           "value":"3000"},
-            {"name":"TARGET_PORT",         "value":"3001"}
+            {"name":"TARGET_PORT",         "value":"3001"},
+            {"name":"ETL_SOURCE_URL",      "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/test-staged"}
           ]'
 
           docker run --rm \

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "image_processing", "~> 1.2"
 gem "lograge"
 gem "lograge-sql"
 
+# Fast JSON parser with streaming/SAX support — used by ETL to process large GeoJSON without OOM
+gem "oj"
+
 group :development, :test do
   # Load environment variables from .env [https://github.com/bkeepers/dotenv]
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
+    oj (3.17.0)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     ostruct (0.6.3)
     pagy (43.5.1)
       json
@@ -465,6 +468,7 @@ DEPENDENCIES
   kamal
   lograge
   lograge-sql
+  oj
   pagy (~> 43.5)
   pg (~> 1.1)
   propshaft

--- a/app/services/etl/http_fetcher.rb
+++ b/app/services/etl/http_fetcher.rb
@@ -16,6 +16,27 @@ module Etl
       Net::HTTP.get(uri)
     end
 
+    # Streams the HTTPS response body to a Tempfile in chunks, never buffering
+    # the full response in memory. Returns the open, rewound Tempfile — caller
+    # is responsible for calling close! when done.
+    def stream_to_tempfile(url)
+      uri = validated_https_uri(url)
+      ext = File.extname(uri.path)
+      tmpfile = Tempfile.new(["etl_download", ext], binmode: true)
+
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request_get(uri.request_uri) do |response|
+          response.read_body { |chunk| tmpfile.write(chunk) }
+        end
+      end
+
+      tmpfile.rewind
+      tmpfile
+    rescue
+      tmpfile&.close!
+      raise
+    end
+
     def head_url(url)
       uri = validated_https_uri(url)
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|

--- a/app/services/etl/importers/epa_sabs_geoms.rb
+++ b/app/services/etl/importers/epa_sabs_geoms.rb
@@ -43,7 +43,7 @@ module Etl
                   INSERT INTO service_area_geometries (pwsid, geom, created_at, updated_at)
                   VALUES ($1, ST_GeomFromGeoJSON($2), NOW(), NOW())
                   ON CONFLICT (pwsid) DO UPDATE
-                    SET geom       = EXCLUDED.geom,
+                    SET geom = EXCLUDED.geom,
                         updated_at = NOW()
                 SQL
                 "EpaSabsGeoms#import!",

--- a/app/services/etl/importers/epa_sabs_geoms.rb
+++ b/app/services/etl/importers/epa_sabs_geoms.rb
@@ -1,24 +1,40 @@
 module Etl
   module Importers
     class EpaSabsGeoms < Etl::FileImporter
-      # Number of features per transaction batch.
       BATCH_SIZE = 500
 
-      def parse(content)
-        geojson = JSON.parse(content)
-        geojson["features"].map do |feature|
-          {
-            pwsid: feature.dig("properties", "pwsid"),
-            geom_json: feature["geometry"].to_json
-          }
+      # Overrides FileImporter#call to stream the GeoJSON from disk one feature
+      # at a time via a SAX parser, keeping only a single BATCH_SIZE window of
+      # rows in memory at any point. This is necessary because the source file
+      # is ~1 GB — loading it into a Ruby string or object tree causes an OOM.
+      def call
+        filename = @file_url.split("/").last
+
+        unless needs_import?
+          log("[ETL] #{filename}: skipped (unchanged since last import)")
+          return :skipped
         end
+
+        log("[ETL] #{filename}: downloading...")
+        started_at = Time.current
+        tempfile = stream_to_tempfile(@file_url)
+        elapsed = (Time.current - started_at).round(1)
+        size_mb = (tempfile.size / 1_048_576.0).round(1)
+        log("[ETL] #{filename}: downloaded #{size_mb} MB in #{elapsed}s, streaming import...")
+
+        count = stream_import(tempfile)
+        raise EmptyImportError, "Import produced 0 rows for #{@file_url}" if count.zero?
+
+        record_import
+        log("[ETL] #{filename}: import complete")
+        :imported
+      ensure
+        tempfile&.close!
       end
 
       def import!(rows)
         conn = ApplicationRecord.connection
 
-        # Each row uses fully parameterized SQL — no string interpolation of
-        # user-controlled data. Batched in transactions to keep throughput high.
         rows.each_slice(BATCH_SIZE) do |batch|
           conn.transaction do
             batch.each do |row|
@@ -27,7 +43,7 @@ module Etl
                   INSERT INTO service_area_geometries (pwsid, geom, created_at, updated_at)
                   VALUES ($1, ST_GeomFromGeoJSON($2), NOW(), NOW())
                   ON CONFLICT (pwsid) DO UPDATE
-                    SET geom     = EXCLUDED.geom,
+                    SET geom       = EXCLUDED.geom,
                         updated_at = NOW()
                 SQL
                 "EpaSabsGeoms#import!",
@@ -39,6 +55,96 @@ module Etl
             end
           end
         end
+      end
+
+      # SAX-style handler that yields one complete feature Hash at a time as
+      # Oj streams through the FeatureCollection. Only the current feature's
+      # data is held in memory — coordinates are never accumulated globally.
+      class FeatureHandler < Oj::Saj
+        def initialize(&on_feature)
+          @on_feature = on_feature
+          @in_features = false  # true once we've entered the "features" array
+          @collecting = false   # true while parsing a single feature object
+          @stack = []           # reconstruction stack for the current feature
+        end
+
+        def hash_start(key)
+          if @collecting
+            h = {}
+            attach(key, h)
+            @stack.push(h)
+          elsif @in_features
+            @collecting = true
+            @stack = [{}]
+          end
+        end
+
+        def hash_end(_key)
+          return unless @collecting
+
+          completed = @stack.pop
+          if @stack.empty?
+            @on_feature.call(completed)
+            @collecting = false
+          end
+        end
+
+        def array_start(key)
+          if @collecting
+            a = []
+            attach(key, a)
+            @stack.push(a)
+          elsif key == "features"
+            @in_features = true
+          end
+        end
+
+        def array_end(key)
+          @stack.pop if @collecting && @stack.last.is_a?(Array)
+          @in_features = false if key == "features"
+        end
+
+        def add_value(value, key)
+          attach(key, value) if @collecting
+        end
+
+        def error(message, line, column)
+          raise "GeoJSON parse error at #{line}:#{column}: #{message}"
+        end
+
+        private
+
+        def attach(key, value)
+          parent = @stack.last
+          case parent
+          when Hash then parent[key] = value
+          when Array then parent << value
+          end
+        end
+      end
+
+      private
+
+      def stream_import(tempfile)
+        count = 0
+        batch = []
+
+        handler = FeatureHandler.new do |feature|
+          batch << {
+            pwsid: feature.dig("properties", "pwsid"),
+            geom_json: Oj.dump(feature["geometry"])
+          }
+          count += 1
+
+          if batch.size >= BATCH_SIZE
+            import!(batch)
+            batch.clear
+          end
+        end
+
+        File.open(tempfile.path) { |f| Oj.saj_parse(handler, f) }
+        import!(batch) unless batch.empty?
+        count
       end
     end
   end

--- a/app/services/etl/post_import_steps.rb
+++ b/app/services/etl/post_import_steps.rb
@@ -9,8 +9,8 @@ module Etl
       generate_centroids
       assign_state_codes
       build_county_associations
-      build_place_crosswalks
       rebuild_spatial_indexes
+      build_place_crosswalks
     end
 
     # Repair invalid geometries using ST_Buffer trick. Runs until none remain
@@ -80,33 +80,43 @@ module Etl
 
     # Rebuild the place_system_crosswalks table from spatial intersections.
     # Runs atomically: the table is either fully rebuilt or left untouched.
+    #
+    # Single-pass CTE: computes ST_Intersection once per pair, derives both
+    # fractions from that result, and filters below-threshold pairs inline.
+    # The explicit && bounding-box pre-filter ensures the GiST index is used.
+    # Must run after rebuild_spatial_indexes so the index is fresh.
     def build_place_crosswalks
       ApplicationRecord.connection.transaction do
         ApplicationRecord.connection.execute("DELETE FROM place_system_crosswalks")
 
         inserted = ApplicationRecord.connection.execute(<<~SQL).cmd_tuples
-          INSERT INTO place_system_crosswalks (geoid, pwsid, created_at, updated_at)
-          SELECT cp.geoid, sag.pwsid, NOW(), NOW()
-          FROM cartographic_places cp
-          JOIN service_area_geometries sag ON ST_Intersects(sag.geom, cp.geom)
+          WITH intersections AS (
+            SELECT
+              cp.geoid,
+              sag.pwsid,
+              ST_Intersection(sag.geom, cp.geom) AS ix_geom,
+              ST_Area(sag.geom)                  AS sag_area,
+              ST_Area(cp.geom)                   AS place_area
+            FROM cartographic_places cp
+            JOIN service_area_geometries sag
+              ON sag.geom && cp.geom
+             AND ST_Intersects(sag.geom, cp.geom)
+          )
+          INSERT INTO place_system_crosswalks
+            (geoid, pwsid, fraction_of_service_area, fraction_of_place, created_at, updated_at)
+          SELECT
+            geoid,
+            pwsid,
+            ST_Area(ix_geom) / NULLIF(sag_area, 0),
+            ST_Area(ix_geom) / NULLIF(place_area, 0),
+            NOW(), NOW()
+          FROM intersections
+          WHERE ST_Area(ix_geom) / NULLIF(sag_area, 0)   >= 0.01
+             OR ST_Area(ix_geom) / NULLIF(place_area, 0) >= 0.01
           ON CONFLICT (geoid, pwsid) DO NOTHING
         SQL
 
-        ApplicationRecord.connection.execute(<<~SQL)
-          UPDATE place_system_crosswalks psc
-          SET fraction_of_service_area = ST_Area(ST_Intersection(sag.geom, cp.geom)) / NULLIF(ST_Area(sag.geom), 0),
-              fraction_of_place        = ST_Area(ST_Intersection(sag.geom, cp.geom)) / NULLIF(ST_Area(cp.geom), 0)
-          FROM service_area_geometries sag
-          JOIN cartographic_places cp ON ST_Intersects(sag.geom, cp.geom)
-          WHERE psc.pwsid = sag.pwsid AND psc.geoid = cp.geoid
-        SQL
-
-        pruned = ApplicationRecord.connection.execute(<<~SQL).cmd_tuples
-          DELETE FROM place_system_crosswalks
-          WHERE fraction_of_service_area < 0.01 OR fraction_of_place < 0.01
-        SQL
-
-        Rails.logger.info("[ETL] build_place_crosswalks: inserted #{inserted}, pruned #{pruned} crosswalk(s)")
+        Rails.logger.info("[ETL] build_place_crosswalks: inserted #{inserted} crosswalk(s)")
       end
     end
 

--- a/docs/ETL.md
+++ b/docs/ETL.md
@@ -65,11 +65,13 @@ Compare each file's `Last-Modified` against the most recent `imported_at` for th
 
 For each file that needs updating:
 
-1. Download the file via HTTP GET into memory
+1. Download the file (streamed to disk for large files — see below)
 2. Parse (CSV or GeoJSON)
 3. Validate row counts and data integrity
 4. Upsert into the live table (`ON CONFLICT UPDATE`)
 5. Record the import in `data_imports`
+
+**Large file handling**: `epa_sabs_geoms.geojson` is ~1 GB and is handled differently from CSVs. It is streamed to a tempfile via chunked HTTP download (`Net::HTTP` block form), then SAX-parsed one feature at a time using `Oj::Saj`. Features are inserted in 500-record batches and the batch is cleared after each insert, keeping peak memory at O(batch_size) rather than O(file_size). This prevents OOM kills in the 1700 MB container.
 
 ### Step 4: Run post-import steps
 
@@ -221,7 +223,7 @@ Configure a recurring job in `config/recurring.yml`:
 ```yaml
 etl_import:
   class: EtlImportJob
-  schedule: every day at 6am
+  schedule: every day at 12am America/New_York
 ```
 
 The job issues HEAD requests per file and only imports files with updated `Last-Modified` timestamps — safe to run frequently.

--- a/spec/services/etl/http_fetcher_spec.rb
+++ b/spec/services/etl/http_fetcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Etl::HttpFetcher do
     Class.new do
       include Etl::HttpFetcher
 
-      public :fetch_url, :head_url
+      public :fetch_url, :head_url, :stream_to_tempfile
     end
   end
 
@@ -91,6 +91,62 @@ RSpec.describe Etl::HttpFetcher do
       it "does not make any HTTP request before raising" do
         allow(Net::HTTP).to receive(:start)
         expect { fetcher.head_url("http://example.com/data.csv") }.to raise_error(Etl::HttpFetcher::InsecureUrlError)
+        expect(Net::HTTP).not_to have_received(:start)
+      end
+    end
+  end
+
+  describe "#stream_to_tempfile" do
+    let(:url) { "https://s3.example.com/data.geojson" }
+
+    context "with a valid HTTPS URL" do
+      let(:mock_http) { instance_double(Net::HTTP) }
+      let(:mock_response) { instance_double(Net::HTTPOK, code: "200") }
+
+      before do
+        allow(Net::HTTP).to receive(:start).and_yield(mock_http)
+        allow(mock_http).to receive(:request_get).and_yield(mock_response)
+        allow(mock_response).to receive(:read_body).and_yield("chunk1").and_yield("chunk2")
+      end
+
+      it "returns a Tempfile containing the streamed body" do
+        tmpfile = fetcher.stream_to_tempfile(url)
+        tmpfile.rewind
+        expect(tmpfile.read).to eq("chunk1chunk2")
+      ensure
+        tmpfile&.close!
+      end
+
+      it "uses SSL" do
+        fetcher.stream_to_tempfile(url)
+        expect(Net::HTTP).to have_received(:start).with("s3.example.com", 443, use_ssl: true)
+
+        # tempfile cleanup — suppress errors if already cleaned up
+      end
+
+      it "streams via read_body chunks rather than buffering the full response" do
+        fetcher.stream_to_tempfile(url)
+        expect(mock_response).to have_received(:read_body)
+
+        # tempfile cleanup
+      end
+    end
+
+    context "with a non-HTTPS URL" do
+      it "raises InsecureUrlError for http://" do
+        expect { fetcher.stream_to_tempfile("http://example.com/f.json") }
+          .to raise_error(Etl::HttpFetcher::InsecureUrlError, /https/i)
+      end
+
+      it "raises InsecureUrlError for file://" do
+        expect { fetcher.stream_to_tempfile("file:///etc/passwd") }
+          .to raise_error(Etl::HttpFetcher::InsecureUrlError)
+      end
+
+      it "does not open any HTTP connection before raising" do
+        allow(Net::HTTP).to receive(:start)
+        expect { fetcher.stream_to_tempfile("http://example.com/f.json") }
+          .to raise_error(Etl::HttpFetcher::InsecureUrlError)
         expect(Net::HTTP).not_to have_received(:start)
       end
     end

--- a/spec/services/etl/importers/epa_sabs_geoms_spec.rb
+++ b/spec/services/etl/importers/epa_sabs_geoms_spec.rb
@@ -1,41 +1,128 @@
 require "rails_helper"
 
 RSpec.describe Etl::Importers::EpaSabsGeoms do
-  let(:geojson_content) { File.read(Rails.root.join("spec/fixtures/etl/epa_sabs_geoms.geojson")) }
-  let(:importer) { described_class.new(file_url: "http://x.com/f.geojson", last_updated: 1.day.ago) }
+  let(:fixture_path) { Rails.root.join("spec/fixtures/etl/epa_sabs_geoms.geojson") }
+  let(:file_url) { "https://s3.example.com/epa_sabs_geoms.geojson" }
+  let(:importer) { described_class.new(file_url: file_url, last_updated: 1.day.ago) }
 
-  describe "#parse" do
-    subject(:rows) { importer.parse(geojson_content) }
+  before do
+    allow($stdout).to receive(:puts)
+    allow($stdout).to receive(:flush)
+  end
 
-    it "returns one row per GeoJSON feature" do
-      expect(rows.length).to eq(1)
+  # Stubs stream_to_tempfile to return a real Tempfile backed by the fixture,
+  # avoiding any network call.
+  def stub_download(path = fixture_path)
+    tmpfile = Tempfile.new(["epa_sabs_geoms", ".geojson"])
+    tmpfile.write(File.read(path))
+    tmpfile.rewind
+    allow(importer).to receive(:stream_to_tempfile).and_return(tmpfile)
+    tmpfile
+  end
+
+  describe "#call" do
+    context "when no prior import exists" do
+      before { create(:public_water_system, pwsid: "VT0000001") }
+
+      it "inserts service_area_geometry records via PostGIS" do
+        stub_download
+        expect { importer.call }.to change(ServiceAreaGeometry, :count).by(1)
+      end
+
+      it "persists a valid geometry" do
+        stub_download
+        importer.call
+        sag = ServiceAreaGeometry.find_by(pwsid: "VT0000001")
+        expect(sag).not_to be_nil
+        expect(sag.geom).not_to be_nil
+      end
+
+      it "returns :imported" do
+        stub_download
+        expect(importer.call).to eq(:imported)
+      end
+
+      it "records a DataImport entry" do
+        stub_download
+        expect { importer.call }.to change(DataImport, :count).by(1)
+      end
+
+      it "stores the correct file_url on the DataImport record" do
+        stub_download
+        importer.call
+        expect(DataImport.last.file_url).to eq(file_url)
+      end
     end
 
-    it "extracts pwsid from feature properties" do
-      expect(rows.first[:pwsid]).to eq("VT0000001")
+    context "when the file is unchanged since last import" do
+      before { create(:data_import, file_url: file_url, imported_at: 1.hour.ago) }
+
+      let(:importer) { described_class.new(file_url: file_url, last_updated: 2.hours.ago) }
+
+      it "returns :skipped without downloading" do
+        expect(importer).not_to receive(:stream_to_tempfile)
+        expect(importer.call).to eq(:skipped)
+      end
+
+      it "does not create a new DataImport record" do
+        expect { importer.call }.not_to change(DataImport, :count)
+      end
     end
 
-    it "stores raw GeoJSON geometry string for SQL import" do
-      parsed = JSON.parse(rows.first[:geom_json])
-      expect(parsed["type"]).to eq("MultiPolygon")
-      expect(parsed["coordinates"]).to be_an(Array)
+    context "when the GeoJSON has no features" do
+      it "raises EmptyImportError and does not record a DataImport" do
+        tmpfile = Tempfile.new(["empty", ".geojson"])
+        tmpfile.write('{"type":"FeatureCollection","features":[]}')
+        tmpfile.rewind
+        allow(importer).to receive(:stream_to_tempfile).and_return(tmpfile)
+
+        expect { importer.call }.to raise_error(Etl::FileImporter::EmptyImportError)
+        expect(DataImport.count).to eq(0)
+      end
+    end
+
+    context "with force: true" do
+      before do
+        create(:public_water_system, pwsid: "VT0000001")
+        create(:data_import, file_url: file_url, imported_at: 1.hour.ago)
+      end
+
+      let(:importer) { described_class.new(file_url: file_url, last_updated: 2.hours.ago, force: true) }
+
+      it "imports even when the file has not changed" do
+        stub_download
+        expect { importer.call }.to change(ServiceAreaGeometry, :count).by(1)
+      end
     end
   end
 
-  describe "#import!" do
-    before { create(:public_water_system, pwsid: "VT0000001") }
+  describe "FeatureHandler" do
+    let(:handler_class) { Etl::Importers::EpaSabsGeoms::FeatureHandler }
 
-    it "inserts service_area_geometry records via PostGIS" do
-      rows = importer.parse(geojson_content)
-      expect { importer.import!(rows) }.to change(ServiceAreaGeometry, :count).by(1)
+    it "yields one hash per GeoJSON feature" do
+      features = []
+      handler = handler_class.new { |f| features << f }
+      Oj.saj_parse(handler, File.read(fixture_path))
+
+      expect(features.length).to eq(1)
     end
 
-    it "persists a valid geometry" do
-      rows = importer.parse(geojson_content)
-      importer.import!(rows)
-      sag = ServiceAreaGeometry.find_by(pwsid: "VT0000001")
-      expect(sag).not_to be_nil
-      expect(sag.geom).not_to be_nil
+    it "extracts pwsid from feature properties" do
+      features = []
+      handler = handler_class.new { |f| features << f }
+      Oj.saj_parse(handler, File.read(fixture_path))
+
+      expect(features.first.dig("properties", "pwsid")).to eq("VT0000001")
+    end
+
+    it "includes geometry as a parseable hash" do
+      features = []
+      handler = handler_class.new { |f| features << f }
+      Oj.saj_parse(handler, File.read(fixture_path))
+
+      geom = features.first["geometry"]
+      expect(geom["type"]).to eq("MultiPolygon")
+      expect(geom["coordinates"]).to be_an(Array)
     end
   end
 end

--- a/spec/services/etl/importers/epa_sabs_geoms_spec.rb
+++ b/spec/services/etl/importers/epa_sabs_geoms_spec.rb
@@ -22,15 +22,16 @@ RSpec.describe Etl::Importers::EpaSabsGeoms do
 
   describe "#call" do
     context "when no prior import exists" do
-      before { create(:public_water_system, pwsid: "VT0000001") }
+      before do
+        create(:public_water_system, pwsid: "VT0000001")
+        stub_download
+      end
 
       it "inserts service_area_geometry records via PostGIS" do
-        stub_download
         expect { importer.call }.to change(ServiceAreaGeometry, :count).by(1)
       end
 
       it "persists a valid geometry" do
-        stub_download
         importer.call
         sag = ServiceAreaGeometry.find_by(pwsid: "VT0000001")
         expect(sag).not_to be_nil
@@ -38,17 +39,14 @@ RSpec.describe Etl::Importers::EpaSabsGeoms do
       end
 
       it "returns :imported" do
-        stub_download
         expect(importer.call).to eq(:imported)
       end
 
       it "records a DataImport entry" do
-        stub_download
         expect { importer.call }.to change(DataImport, :count).by(1)
       end
 
       it "stores the correct file_url on the DataImport record" do
-        stub_download
         importer.call
         expect(DataImport.last.file_url).to eq(file_url)
       end
@@ -85,12 +83,12 @@ RSpec.describe Etl::Importers::EpaSabsGeoms do
       before do
         create(:public_water_system, pwsid: "VT0000001")
         create(:data_import, file_url: file_url, imported_at: 1.hour.ago)
+        stub_download
       end
 
       let(:importer) { described_class.new(file_url: file_url, last_updated: 2.hours.ago, force: true) }
 
       it "imports even when the file has not changed" do
-        stub_download
         expect { importer.call }.to change(ServiceAreaGeometry, :count).by(1)
       end
     end


### PR DESCRIPTION
## Summary

Fixes a production OOM kill in the nightly ETL job caused by loading a 1 GB GeoJSON file entirely into memory — replaced with chunked HTTP streaming and SAX parsing so peak memory is O(batch_size), not O(file_size).

## Changes
- **ETL streaming fix for `epa_sabs_geoms.geojson`**
  - `HttpFetcher#stream_to_tempfile` streams the HTTP response body to disk in chunks via `Net::HTTP` block form — never buffers the full file in memory
  - `EpaSabsGeoms` importer rewritten to SAX-parse the tempfile one feature at a time using `Oj::Saj`, yielding features in 500-record batches to `import!` — peak memory stays constant regardless of file size
  - `oj` gem added as a dependency
  - Full spec coverage for both `stream_to_tempfile` and the SAX `FeatureHandler`

## Notes for reviewers

The `EpaSabsGeoms` importer now fully overrides `FileImporter#call` rather than delegating to `parse` — this is intentional since the SAX approach requires a different execution path (download → stream from disk) that doesn't fit the base class's synchronous parse model. The base class `import!` method is kept unchanged.

The `oj` gem's SAX interface (`Oj::Saj`) requires careful stack management in `FeatureHandler` — the spec exercises this directly against a real fixture file to catch any regression in the callback logic.
