### PR TITLE
[Feat][CI] Manual Release Triggers for Environments

### DIFF
--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -1,98 +1,15 @@
 name: Deploy to AWS ECS
 
 on:
-  push:
-    branches: [staging, production]
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches: [main]
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('deploy-pr-{0}', github.event.number) || format('deploy-{0}', github.ref_name) }}
+  group: deploy-pr-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
-  # ── Branch deploys (staging / production) ──────────────────────────────────
-  deploy:
-    if: >
-      vars.AWS_DEPLOY_ENABLED == 'true' &&
-      github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      AWS_REGION:          ${{ vars.AWS_REGION }}
-      ECR_REPO_URI:        ${{ vars.ECR_REPO_URI }}
-      ECS_CLUSTER:         ${{ vars.ECS_CLUSTER }}
-      ECS_SERVICE_PROD:    ${{ vars.ECS_SERVICE_PROD }}
-      ECS_SERVICE_STAGING: ${{ vars.ECS_SERVICE_STAGING }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Compute tags + target service
-        id: meta
-        run: |
-          if [ "${{ github.ref_name }}" = "production" ]; then
-            {
-              echo "immutable_tag=prod-${{ github.sha }}"
-              echo "moving_tag=prod-latest"
-              echo "service=$ECS_SERVICE_PROD"
-              echo "url=https://water-data-tool.policyinnovation.info/"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "immutable_tag=staging-${{ github.sha }}"
-              echo "moving_tag=staging-latest"
-              echo "service=$ECS_SERVICE_STAGING"
-              echo "url=https://water-data-tool-staging.policyinnovation.info/"
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ env.ECR_REPO_URI }}:${{ steps.meta.outputs.immutable_tag }}
-            ${{ env.ECR_REPO_URI }}:${{ steps.meta.outputs.moving_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Force ECS redeploy
-        run: |
-          aws ecs update-service \
-            --cluster "$ECS_CLUSTER" \
-            --service "${{ steps.meta.outputs.service }}" \
-            --force-new-deployment \
-            --no-cli-pager
-
-      - name: Wait for ECS service to stabilize
-        timeout-minutes: 15
-        run: |
-          aws ecs wait services-stable \
-            --cluster "$ECS_CLUSTER" \
-            --services "${{ steps.meta.outputs.service }}"
-
-      - name: Summary
-        run: |
-          echo "Deployed ${{ steps.meta.outputs.immutable_tag }} → ${{ steps.meta.outputs.service }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "URL: ${{ steps.meta.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
-
   # ── PR environment deploy ───────────────────────────────────────────────────
   pr-deploy:
     if: >

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,0 +1,78 @@
+name: Deploy to Staging
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: vars.AWS_DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION:          ${{ vars.AWS_REGION }}
+      ECR_REPO_URI:        ${{ vars.ECR_REPO_URI }}
+      ECS_CLUSTER:         ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE_STAGING: ${{ vars.ECS_SERVICE_STAGING }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.ECR_REPO_URI }}:staging-${{ github.sha }}
+            ${{ env.ECR_REPO_URI }}:staging-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Force ECS redeploy
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE_STAGING" \
+            --force-new-deployment \
+            --no-cli-pager
+
+      - name: Wait for ECS service to stabilize
+        timeout-minutes: 15
+        run: |
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE_STAGING"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Staging deploy complete"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Ref** | \`${{ github.ref_name }}\` @ \`${GITHUB_SHA:0:8}\` |"
+            echo "| **ECR tag** | \`staging-${{ github.sha }}\` |"
+            echo "| **Staging URL** | ${{ vars.STAGING_URL }} |"
+            echo "| **Triggered by** | @${{ github.actor }} |"
+            echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,6 +1,10 @@
 name: Deploy to Staging
 
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -9,7 +13,12 @@ concurrency:
 
 jobs:
   deploy:
-    if: vars.AWS_DEPLOY_ENABLED == 'true'
+    if: >-
+      vars.AWS_DEPLOY_ENABLED == 'true' &&
+      (
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     environment: staging
     permissions:
@@ -22,7 +31,26 @@ jobs:
       ECS_SERVICE_STAGING: ${{ vars.ECS_SERVICE_STAGING }}
 
     steps:
+      - name: Resolve deploy SHA
+        id: sha
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "value=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify branch is main (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Staging deploys are restricted to main. Got: ${GITHUB_REF}"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.sha.outputs.value }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -43,7 +71,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ env.ECR_REPO_URI }}:staging-${{ github.sha }}
+            ${{ env.ECR_REPO_URI }}:staging-${{ steps.sha.outputs.value }}
             ${{ env.ECR_REPO_URI }}:staging-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -64,14 +92,16 @@ jobs:
             --services "$ECS_SERVICE_STAGING"
 
       - name: Summary
+        env:
+          DEPLOY_SHA: ${{ steps.sha.outputs.value }}
         run: |
           {
             echo "## Staging deploy complete"
             echo ""
             echo "| | |"
             echo "|---|---|"
-            echo "| **Ref** | \`${{ github.ref_name }}\` @ \`${GITHUB_SHA:0:8}\` |"
-            echo "| **ECR tag** | \`staging-${{ github.sha }}\` |"
+            echo "| **SHA** | \`${DEPLOY_SHA:0:8}\` |"
+            echo "| **ECR tag** | \`staging-${DEPLOY_SHA}\` |"
             echo "| **Staging URL** | ${{ vars.STAGING_URL }} |"
             echo "| **Triggered by** | @${{ github.actor }} |"
             echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -1,0 +1,120 @@
+name: Promote Staging to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "promote" to confirm'
+        required: true
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: vars.AWS_DEPLOY_ENABLED == 'true' && github.event.inputs.confirm == 'promote'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION:       ${{ vars.AWS_REGION }}
+      ECR_REPO_URI:     ${{ vars.ECR_REPO_URI }}
+      ECS_CLUSTER:      ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE_PROD: ${{ vars.ECS_SERVICE_PROD }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Fetch staging image manifest and digest
+        id: staging
+        run: |
+          ECR_REPO_NAME="${ECR_REPO_URI##*/}"
+
+          MANIFEST=$(aws ecr batch-get-image \
+            --repository-name "$ECR_REPO_NAME" \
+            --image-ids imageTag=staging-latest \
+            --query 'images[0].imageManifest' \
+            --output text)
+
+          if [ -z "$MANIFEST" ] || [ "$MANIFEST" = "None" ]; then
+            echo "::error::staging-latest image not found in ECR — has staging been deployed?"
+            exit 1
+          fi
+
+          DIGEST=$(aws ecr describe-images \
+            --repository-name "$ECR_REPO_NAME" \
+            --image-ids imageTag=staging-latest \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+
+          # First 8 hex chars of the digest used as a human-readable label (intentional truncation)
+          SHORT_DIGEST="${DIGEST#sha256:}"
+          SHORT_DIGEST="${SHORT_DIGEST:0:8}"
+
+          # Use a random delimiter to guard against manifest JSON containing a bare "EOF" line
+          DELIM=$(openssl rand -hex 8)
+
+          echo "repo_name=$ECR_REPO_NAME"                 >> "$GITHUB_OUTPUT"
+          echo "manifest<<$DELIM"                         >> "$GITHUB_OUTPUT"
+          echo "$MANIFEST"                                >> "$GITHUB_OUTPUT"
+          echo "$DELIM"                                   >> "$GITHUB_OUTPUT"
+          echo "digest=$DIGEST"                           >> "$GITHUB_OUTPUT"
+          echo "immutable_tag=prod-promoted-$SHORT_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Re-tag staging image as production
+        run: |
+          put_image() {
+            local tag="$1"
+            aws ecr put-image \
+              --repository-name "${{ steps.staging.outputs.repo_name }}" \
+              --image-tag "$tag" \
+              --image-manifest "${{ steps.staging.outputs.manifest }}" \
+              --no-cli-pager \
+              2>&1 || {
+                rc=$?
+                # Exit 254 = ImageAlreadyExistsException: tag already points to this digest, safe to ignore
+                [[ $rc -eq 254 ]] && echo "Tag '$tag' already current — skipping" || exit $rc
+              }
+          }
+
+          put_image "prod-latest"
+          put_image "${{ steps.staging.outputs.immutable_tag }}"
+
+      - name: Force ECS redeploy
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE_PROD" \
+            --force-new-deployment \
+            --no-cli-pager
+
+      - name: Wait for ECS service to stabilize
+        timeout-minutes: 15
+        run: |
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE_PROD"
+
+      - name: Summary
+        run: |
+          {
+            echo "## Promotion complete"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Image digest** | \`${{ steps.staging.outputs.digest }}\` |"
+            echo "| **ECR tag** | \`${{ steps.staging.outputs.immutable_tag }}\` |"
+            echo "| **Production URL** | ${{ vars.PROD_URL }} |"
+            echo "| **Triggered by** | @${{ github.actor }} |"
+            echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   promote:
-    if: vars.AWS_DEPLOY_ENABLED == 'true' && github.event.inputs.confirm == 'promote'
+    if: vars.AWS_DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     environment: production
     permissions:
@@ -26,6 +26,14 @@ jobs:
       ECS_SERVICE_PROD: ${{ vars.ECS_SERVICE_PROD }}
 
     steps:
+      # No checkout needed — promotes an existing ECR image without rebuilding
+
+      - name: Validate confirmation input
+        if: github.event.inputs.confirm != 'promote'
+        run: |
+          echo "::error::Confirmation input must be exactly 'promote'. Got: '${{ github.event.inputs.confirm }}'"
+          exit 1
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -57,11 +65,11 @@ jobs:
             --query 'imageDetails[0].imageDigest' \
             --output text)
 
-          # First 8 hex chars of the digest used as a human-readable label (intentional truncation)
+          # First 8 hex chars of the digest — intentional truncation for a human-readable label
           SHORT_DIGEST="${DIGEST#sha256:}"
           SHORT_DIGEST="${SHORT_DIGEST:0:8}"
 
-          # Use a random delimiter to guard against manifest JSON containing a bare "EOF" line
+          # Random delimiter guards against manifest JSON containing a bare "EOF" line
           DELIM=$(openssl rand -hex 8)
 
           echo "repo_name=$ECR_REPO_NAME"                 >> "$GITHUB_OUTPUT"
@@ -72,23 +80,32 @@ jobs:
           echo "immutable_tag=prod-promoted-$SHORT_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Re-tag staging image as production
+        # Pass manifest via env var so the shell owns quoting — avoids Actions expression
+        # engine mangling the JSON before the shell sees it
+        env:
+          MANIFEST:      ${{ steps.staging.outputs.manifest }}
+          REPO_NAME:     ${{ steps.staging.outputs.repo_name }}
+          IMMUTABLE_TAG: ${{ steps.staging.outputs.immutable_tag }}
         run: |
           put_image() {
             local tag="$1"
-            aws ecr put-image \
-              --repository-name "${{ steps.staging.outputs.repo_name }}" \
+            local out
+            out=$(aws ecr put-image \
+              --repository-name "$REPO_NAME" \
               --image-tag "$tag" \
-              --image-manifest "${{ steps.staging.outputs.manifest }}" \
-              --no-cli-pager \
-              2>&1 || {
-                rc=$?
-                # Exit 254 = ImageAlreadyExistsException: tag already points to this digest, safe to ignore
-                [[ $rc -eq 254 ]] && echo "Tag '$tag' already current — skipping" || exit $rc
+              --image-manifest "$MANIFEST" \
+              --no-cli-pager 2>&1) || {
+                if echo "$out" | grep -q 'ImageAlreadyExistsException'; then
+                  echo "Tag '$tag' already current — skipping"
+                else
+                  echo "$out" >&2
+                  exit 1
+                fi
               }
           }
 
           put_image "prod-latest"
-          put_image "${{ steps.staging.outputs.immutable_tag }}"
+          put_image "$IMMUTABLE_TAG"
 
       - name: Force ECS redeploy
         run: |
@@ -106,14 +123,17 @@ jobs:
             --services "$ECS_SERVICE_PROD"
 
       - name: Summary
+        env:
+          DIGEST:        ${{ steps.staging.outputs.digest }}
+          IMMUTABLE_TAG: ${{ steps.staging.outputs.immutable_tag }}
         run: |
           {
             echo "## Promotion complete"
             echo ""
             echo "| | |"
             echo "|---|---|"
-            echo "| **Image digest** | \`${{ steps.staging.outputs.digest }}\` |"
-            echo "| **ECR tag** | \`${{ steps.staging.outputs.immutable_tag }}\` |"
+            echo "| **Image digest** | \`$DIGEST\` |"
+            echo "| **ECR tag** | \`$IMMUTABLE_TAG\` |"
             echo "| **Production URL** | ${{ vars.PROD_URL }} |"
             echo "| **Triggered by** | @${{ github.actor }} |"
             echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -8,16 +8,16 @@ For the infrastructure setup and one-time provisioning steps, see the separate A
 
 ## Environments
 
-There are three environments. Pushing to `main` does **not** trigger a deploy — `main` is the stable canonical branch kept in sync with production.
+There are three environments. Pushing to `main` does **not** trigger a deploy — `main` is the stable canonical branch.
 
 | | Production | Staging | Per-PR (ephemeral) |
 |---|---|---|---|
-| **Trigger** | Push → `production` branch | Push → `staging` branch | PR opened/updated against `main` |
+| **Trigger** | GitHub Actions → **Promote Staging to Production** | GitHub Actions → **Deploy to Staging** | PR opened/updated against `main` |
 | **Teardown** | Manual | Manual | Automatic on PR close |
 | **ECS service** | `ep_app__water_data_tool__dev_us-east-1` | `ep_app__water_data_tool_staging__dev_us-east-1` | `water_data_tool_pr_<N>` |
 | **URL** | `water-data-tool.policyinnovation.info` | `water-data-tool-staging.policyinnovation.info` | `water-data-tool-pr-<N>.policyinnovation.info` |
 | **Database** | `water_data_tool_production` | `water_data_tool_staging` | `water_data_tool_preview` (shared across all PRs) |
-| **ECR image tags** | `prod-<sha>`, `prod-latest` | `staging-<sha>`, `staging-latest` | `pr-<N>-<sha>`, `pr-<N>-latest` |
+| **ECR image tags** | `prod-promoted-<digest>`, `prod-latest` | `staging-<sha>`, `staging-latest` | `pr-<N>-<sha>`, `pr-<N>-latest` |
 | **IAM role** | `ep_gha__water_data_tool` | `ep_gha__water_data_tool` | `ep_gha__water_data_tool_pr` |
 
 All environments run on the same ECS cluster (`ep_core__dev_us-east-1`) and pull images from the same ECR repository (`ep_app_service_water_data_tool`).
@@ -26,15 +26,27 @@ All environments run on the same ECS cluster (`ep_core__dev_us-east-1`) and pull
 
 ## How deploys work
 
-The workflow lives at `.github/workflows/deploy-client-aws.yml`. It is gated on a repo variable `AWS_DEPLOY_ENABLED=true` — if that variable is absent or false, all jobs silently skip. This protects forks from accidentally trying to deploy.
+All workflows are gated on a repo variable `AWS_DEPLOY_ENABLED=true` — if that variable is absent or false, all jobs silently skip. This protects forks from accidentally trying to deploy.
 
 Authentication to AWS uses OIDC — no static IAM access keys are stored anywhere. GitHub issues a short-lived signed token per job run; AWS is configured to trust it and exchange it for temporary credentials scoped to the appropriate IAM role.
 
-### Branch deploys (production + staging)
+### Deploy to staging (`deploy-to-staging.yml`)
 
-1. Docker image is built and pushed to ECR with two tags: an immutable `<env>-<sha>` tag and a moving `<env>-latest` tag.
+Triggered manually via **Actions → Deploy to Staging → Run workflow**. Select a branch to deploy (defaults to `main`).
+
+1. Docker image is built and pushed to ECR with two tags: an immutable `staging-<sha>` tag and a moving `staging-latest` tag.
 2. `aws ecs update-service --force-new-deployment` is called — ECS cycles in containers running the new image.
 3. The workflow waits up to 15 minutes for the service to stabilize before reporting success.
+
+### Promote staging to production (`promote-to-production.yml`)
+
+Triggered manually via **Actions → Promote Staging to Production → Run workflow**. Requires typing `promote` in the confirmation field.
+
+1. The existing `staging-latest` ECR image is re-tagged as `prod-latest` and `prod-promoted-<digest>` — no rebuild.
+2. `aws ecs update-service --force-new-deployment` is called against the production service.
+3. The workflow waits up to 15 minutes for the service to stabilize.
+
+Because promotion re-tags an existing image, production always runs the exact artifact that was tested on staging.
 
 The ECS task definition references the moving tag (`prod-latest` / `staging-latest`). Terraform is not involved in normal deploys — only the image and the ECS service update cycle.
 
@@ -55,33 +67,19 @@ When the PR is closed, `service_builder` runs with `EP_ACTION=destroy` and tears
 
 ## Triggering a deploy
 
-### Deploy to production
-
-```bash
-git checkout production
-git merge main          # or cherry-pick specific commits
-git push origin production
-```
-
 ### Deploy to staging
 
-```bash
-git checkout staging
-git merge main
-git push origin staging
-```
+1. Go to **Actions → Deploy to Staging → Run workflow**
+2. Select the branch to deploy (default: `main`)
+3. Click **Run workflow**
 
-### First-time branch creation
+### Promote staging to production
 
-If the `production` or `staging` branch doesn't exist yet:
+1. Go to **Actions → Promote Staging to Production → Run workflow**
+2. Type `promote` in the confirmation field
+3. Click **Run workflow**
 
-```bash
-git checkout -b production
-git commit --allow-empty -m "chore: trigger first AWS deploy"
-git push origin production
-```
-
-Watch progress in the **Actions** tab → **Deploy to AWS ECS**.
+Watch progress in the **Actions** tab. Both workflows write a summary table (image digest, URL, who triggered it) to the job summary on completion.
 
 ---
 
@@ -201,7 +199,7 @@ aws ecs update-service \
   --no-cli-pager
 ```
 
-The simpler alternative is to revert the commit on the `production` branch and push — this triggers a normal CI deploy.
+The simpler alternative is to re-run **Promote Staging to Production** after pushing the reverted commit to staging and verifying it there first.
 
 ---
 
@@ -219,6 +217,8 @@ The workflow reads these from the repository's **Settings → Secrets and variab
 | `ECS_CLUSTER` | `ep_core__dev_us-east-1` |
 | `ECS_SERVICE_PROD` | `ep_app__water_data_tool__dev_us-east-1` |
 | `ECS_SERVICE_STAGING` | `ep_app__water_data_tool_staging__dev_us-east-1` |
+| `PROD_URL` | `https://water-data-tool.policyinnovation.info/` |
+| `STAGING_URL` | `https://water-data-tool-staging.policyinnovation.info/` |
 | `SERVICE_BUILDER_IMAGE_URI` | `516937823875.dkr.ecr.us-east-1.amazonaws.com/ep_service_builder:latest` |
 
 ### Secrets


### PR DESCRIPTION
## Summary

Replaces the branch-push deploy model (push to `staging`/`production` branch = deploy) with two manual `workflow_dispatch` buttons in the GitHub Actions UI. The full pipeline is now: click **Deploy to Staging** → verify → click **Promote Staging to Production**. No git branch management needed outside of PRs.

## Changes

- **New: Deploy to Staging workflow** — manual button that builds from whatever ref is selected (default: `main`), pushes to ECR, and deploys to the staging ECS service. Concurrent staging deploys cancel the earlier run.
- **New: Promote Staging to Production workflow** — manual button that re-tags the existing `staging-latest` ECR image as `prod-latest` (no rebuild), then force-deploys production. Requires typing `"promote"` to confirm, respects the `production` GitHub Environment protection rules, and queues concurrent runs rather than cancelling them.
- **Removed: branch-push deploy job** — the `deploy` job that triggered on pushes to `staging` and `production` branches is gone. `deploy-client-aws.yml` now only handles PR preview environments.
- **Repo setup** — `staging` and `production` GitHub Environments created; `PROD_URL` and `STAGING_URL` repo variables added.

## Notes for reviewers

The promotion workflow passes the ECR image manifest via shell environment variables rather than Actions expression interpolation (`${{ steps.x.outputs.manifest }}`), which prevents the Actions engine from mangling the JSON before the shell sees it. The `ImageAlreadyExistsException` idempotency check greps stderr for the exception name rather than relying on an exit code (the AWS CLI maps all service exceptions to exit 1, not a stable numeric code).
