### PR TITLE
[Hotfix][5-7-26] Lookbook Gem Issues Causing Failed Builds

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,11 @@ module WaterDataTool
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Lookbook preview files inherit from Lookbook::Preview, a development-only gem.
+    # Zeitwerk must ignore this directory in all environments; Lookbook discovers
+    # previews by scanning the filesystem itself, not through the autoloader.
+    Rails.autoloaders.main.ignore(Rails.root.join("app/components/previews"))
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/view_component.rb
+++ b/config/initializers/view_component.rb
@@ -1,1 +1,5 @@
-Rails.application.config.view_component.previews.paths << Rails.root.join("app/components/previews").to_s
+# Register the previews directory with Lookbook only in development.
+# Zeitwerk ignores this directory in all environments (see config/application.rb).
+if Rails.env.development?
+  Rails.application.config.view_component.previews.paths << Rails.root.join("app/components/previews").to_s
+end


### PR DESCRIPTION
## Summary

Fixes a production/staging crash introduced when ViewComponent previews were added in #145. The `lookbook` gem is development-only, but `app/components/previews/` was being eager-loaded by Zeitwerk in all environments, causing a `NameError: uninitialized constant Lookbook` on boot and a 503.

## Changes

- Tell Zeitwerk to ignore `app/components/previews/` unconditionally in `config/application.rb` — Lookbook discovers preview files by scanning the filesystem itself, not through the autoloader, so development behaviour is unchanged
- Guard the ViewComponent previews path registration in the initializer to development-only, since it's irrelevant in other environments

## Notes for reviewers

The `Rails.autoloaders.main.ignore` call must live in `config/application.rb`, not an initializer — the autoloader is already set up by the time initializers run. Confirmed fix with a `RAILS_ENV=production rails runner` boot check before committing.
