### PR TITLE
[FEAT] Format External Links - use ViewComponents

### DIFF
--- a/app/components/filters/category_component.rb
+++ b/app/components/filters/category_component.rb
@@ -12,6 +12,6 @@ class Filters::CategoryComponent < ViewComponent::Base
 
   def heading_classes
     variant_classes = (@variant == :light) ? LIGHT_VARIANT_CLASSES : DEFAULT_VARIANT_CLASSES
-    "#{BASE_HEADING_CLASSES} #{variant_classes}"
+    class_names(BASE_HEADING_CLASSES, variant_classes)
   end
 end

--- a/app/components/filters/pop_size_group_component.rb
+++ b/app/components/filters/pop_size_group_component.rb
@@ -19,8 +19,8 @@ class Filters::PopSizeGroupComponent < ViewComponent::Base
 
   def button_classes
     case @position
-    when :first then "#{BASE_CLASSES} border-l rounded-l-[10px]"
-    when :last then "#{BASE_CLASSES} rounded-r-[10px]"
+    when :first then class_names(BASE_CLASSES, "border-l rounded-l-[10px]")
+    when :last then class_names(BASE_CLASSES, "rounded-r-[10px]")
     else BASE_CLASSES
     end
   end

--- a/app/components/previews/ui/circle_button_component_preview.rb
+++ b/app/components/previews/ui/circle_button_component_preview.rb
@@ -8,7 +8,7 @@ class UI::CircleButtonComponentPreview < Lookbook::Preview
 
   # @label Text button (region shortcut)
   def text_button
-    render UI::CircleButtonComponent.new(aria_label: "Zoom to Hawaii", data_action: "click->map#zoomHi", extra_classes: "text-xs") do
+    render UI::CircleButtonComponent.new(aria_label: "Zoom to Hawaii", data_action: "click->map#zoomHi", classes: "text-xs") do
       "HI"
     end
   end

--- a/app/components/previews/ui/download_link_component_preview.rb
+++ b/app/components/previews/ui/download_link_component_preview.rb
@@ -1,0 +1,15 @@
+class UI::DownloadLinkComponentPreview < Lookbook::Preview
+  # @label Default
+  def default
+    render UI::DownloadLinkComponent.new(url: "https://example.com/data.zip") do
+      "National"
+    end
+  end
+
+  # @label No icon
+  def no_icon
+    render UI::DownloadLinkComponent.new(url: "https://example.com/data.zip", show_icon: false) do
+      "National"
+    end
+  end
+end

--- a/app/components/previews/ui/download_link_component_preview.rb
+++ b/app/components/previews/ui/download_link_component_preview.rb
@@ -1,14 +1,14 @@
 class UI::DownloadLinkComponentPreview < Lookbook::Preview
   # @label Default
   def default
-    render UI::DownloadLinkComponent.new(url: "https://example.com/data.zip") do
+    render UI::DownloadLinkComponent.new(url: "https://example.com/staged/national_pws_data.zip") do
       "National"
     end
   end
 
   # @label No icon
   def no_icon
-    render UI::DownloadLinkComponent.new(url: "https://example.com/data.zip", show_icon: false) do
+    render UI::DownloadLinkComponent.new(url: "https://example.com/staged/national_pws_data.zip", show_icon: false) do
       "National"
     end
   end

--- a/app/components/previews/ui/external_link_component_preview.rb
+++ b/app/components/previews/ui/external_link_component_preview.rb
@@ -1,0 +1,22 @@
+class UI::ExternalLinkComponentPreview < Lookbook::Preview
+  # @label Default (inline text link)
+  def default
+    render UI::ExternalLinkComponent.new(url: "https://example.com") do
+      "documentation"
+    end
+  end
+
+  # @label Custom color
+  def custom_color
+    render UI::ExternalLinkComponent.new(url: "https://example.com", classes: "text-brand-primary") do
+      "methodology PDF"
+    end
+  end
+
+  # @label No icon
+  def no_icon
+    render UI::ExternalLinkComponent.new(url: "https://example.com", show_icon: false) do
+      "plain link"
+    end
+  end
+end

--- a/app/components/previews/ui/mailto_link_component_preview.rb
+++ b/app/components/previews/ui/mailto_link_component_preview.rb
@@ -1,0 +1,22 @@
+class UI::MailtoLinkComponentPreview < Lookbook::Preview
+  # @label Default (inline text link)
+  def default
+    render UI::MailtoLinkComponent.new(email: "watertool@policyinnovation.org") do
+      "watertool@policyinnovation.org"
+    end
+  end
+
+  # @label Label text
+  def label_text
+    render UI::MailtoLinkComponent.new(email: "watertool@policyinnovation.org") do
+      "Contact EPIC"
+    end
+  end
+
+  # @label No icon
+  def no_icon
+    render UI::MailtoLinkComponent.new(email: "watertool@policyinnovation.org", show_icon: false) do
+      "watertool@policyinnovation.org"
+    end
+  end
+end

--- a/app/components/previews/ui/nav_item_component_preview.rb
+++ b/app/components/previews/ui/nav_item_component_preview.rb
@@ -23,4 +23,13 @@ class UI::NavItemComponentPreview < Lookbook::Preview
       external: true
     )
   end
+
+  # @label Link — mailto (Contact EPIC)
+  def mailto_link
+    render UI::NavItemComponent.new(
+      label: "Contact EPIC",
+      icon_name: "email",
+      href: "mailto:watertool@policyinnovation.org"
+    )
+  end
 end

--- a/app/components/ui/circle_button_component.rb
+++ b/app/components/ui/circle_button_component.rb
@@ -5,14 +5,14 @@ class UI::CircleButtonComponent < ViewComponent::Base
     "border border-neutral-300 text-[#444] cursor-pointer hover:bg-neutral-100 " \
     "#{FOCUS_RING_CLASSES}".freeze
 
-  def initialize(aria_label:, data_action: nil, id: nil, extra_classes: nil)
+  def initialize(aria_label:, data_action: nil, id: nil, classes: nil)
     @aria_label = aria_label
     @data_action = data_action
     @id = id
-    @extra_classes = extra_classes
+    @classes = classes
   end
 
   def button_classes
-    [BASE_CLASSES, @extra_classes].compact.join(" ")
+    class_names(BASE_CLASSES, @classes)
   end
 end

--- a/app/components/ui/dataset_card_component.html.erb
+++ b/app/components/ui/dataset_card_component.html.erb
@@ -7,7 +7,7 @@
       <p class="text-sm text-gray-600 mb-4"><%= @description %></p>
       <div class="border-t border-b border-gray-200 py-3 mb-4 space-y-1">
         <p class="text-sm text-gray-600">
-          Data source: <%= render UI::ExternalLinkComponent.new(url: @source_url, aria_label: "#{@source_name} (opens in new tab)", css_class: "text-gray-700 underline hover:text-gray-900") do %><%= @source_name %><% end %>
+          Data source: <%= render UI::ExternalLinkComponent.new(url: @source_url, classes: "text-gray-700 underline hover:text-gray-900") do %><%= @source_name %><% end %>
         </p>
         <p class="text-sm text-gray-600">Last updated: <span class="date"><%= formatted_date %></span></p>
         <p class="text-sm text-gray-600">Update frequency: <%= frequency_label %></p>

--- a/app/components/ui/dataset_card_component.html.erb
+++ b/app/components/ui/dataset_card_component.html.erb
@@ -7,7 +7,7 @@
       <p class="text-sm text-gray-600 mb-4"><%= @description %></p>
       <div class="border-t border-b border-gray-200 py-3 mb-4 space-y-1">
         <p class="text-sm text-gray-600">
-          Data source: <%= render UI::ExternalLinkComponent.new(url: @source_url, classes: "text-gray-700 underline hover:text-gray-900") do %><%= @source_name %><% end %>
+          Data source: <%= render UI::ExternalLinkComponent.new(url: @source_url, classes: "text-gray-700 hover:text-gray-900") do %><%= @source_name %><% end %>
         </p>
         <p class="text-sm text-gray-600">Last updated: <span class="date"><%= formatted_date %></span></p>
         <p class="text-sm text-gray-600">Update frequency: <%= frequency_label %></p>

--- a/app/components/ui/download_link_component.rb
+++ b/app/components/ui/download_link_component.rb
@@ -1,15 +1,17 @@
 class UI::DownloadLinkComponent < ViewComponent::Base
   include ApplicationHelper
 
-  def initialize(url:, show_icon: true, css_class: "inline-flex items-center gap-1.5 text-black font-bold")
+  BASE_CLASSES = "inline-flex items-center gap-1.5 text-black font-bold"
+
+  def initialize(url:, show_icon: true, classes: nil)
     @url = url
     @show_icon = show_icon
-    @css_class = css_class
+    @classes = classes
   end
 
   def call
     tag.a(href: @url, target: "_blank", rel: "noopener noreferrer",
-      title: "Download file", download: true, class: @css_class) do
+      title: "Download file", download: true, class: class_names(BASE_CLASSES, @classes)) do
       parts = []
       parts << icon("downloads", classes: "w-4 h-4 shrink-0") if @show_icon
       parts << content

--- a/app/components/ui/download_link_component.rb
+++ b/app/components/ui/download_link_component.rb
@@ -15,7 +15,7 @@ class UI::DownloadLinkComponent < ViewComponent::Base
       parts = []
       parts << icon("downloads", classes: "w-4 h-4 shrink-0") if @show_icon
       parts << content
-      parts << tag.span("(download)", class: "sr-only")
+      parts << tag.span("(downloads file)", class: "sr-only")
       safe_join(parts)
     end
   end

--- a/app/components/ui/external_link_component.rb
+++ b/app/components/ui/external_link_component.rb
@@ -1,9 +1,9 @@
 class UI::ExternalLinkComponent < ViewComponent::Base
   include ApplicationHelper
 
-  BASE_CLASSES = "inline-flex items-center gap-0.5"
+  BASE_CLASSES = "inline-flex items-center gap-0.5 underline"
 
-  def initialize(url:, show_icon: true, classes: "underline")
+  def initialize(url:, show_icon: true, classes: nil)
     @url = url
     @show_icon = show_icon
     @classes = classes

--- a/app/components/ui/external_link_component.rb
+++ b/app/components/ui/external_link_component.rb
@@ -1,17 +1,18 @@
 class UI::ExternalLinkComponent < ViewComponent::Base
   include ApplicationHelper
 
-  BASE_CLASSES = "inline-flex items-center gap-0.5 underline"
+  BASE_CLASSES = "inline-flex items-center gap-0.5"
 
-  def initialize(url:, show_icon: true, classes: nil)
+  def initialize(url:, show_icon: true, underline: true, classes: nil)
     @url = url
     @show_icon = show_icon
+    @underline = underline
     @classes = classes
   end
 
   def call
     tag.a(href: @url, target: "_blank", rel: "noopener noreferrer",
-      title: "Opens in new tab", class: class_names(BASE_CLASSES, @classes)) do
+      title: "Opens in new tab", class: class_names(BASE_CLASSES, @underline && "underline", @classes)) do
       parts = []
       parts << content
       parts << icon("external-link", classes: "w-3.5 h-3.5 shrink-0") if @show_icon

--- a/app/components/ui/external_link_component.rb
+++ b/app/components/ui/external_link_component.rb
@@ -1,14 +1,22 @@
 class UI::ExternalLinkComponent < ViewComponent::Base
-  def initialize(url:, aria_label: nil, css_class: "underline")
+  include ApplicationHelper
+
+  BASE_CLASSES = "inline-flex items-center gap-0.5"
+
+  def initialize(url:, show_icon: true, classes: "underline")
     @url = url
-    @aria_label = aria_label
-    @css_class = css_class
+    @show_icon = show_icon
+    @classes = classes
   end
 
   def call
     tag.a(href: @url, target: "_blank", rel: "noopener noreferrer",
-      title: "Opens in new tab", "aria-label": @aria_label, class: @css_class) do
-      safe_join([content, tag.span("(opens in new tab)", class: "sr-only")])
+      title: "Opens in new tab", class: class_names(BASE_CLASSES, @classes)) do
+      parts = []
+      parts << content
+      parts << icon("external-link", classes: "w-3.5 h-3.5 shrink-0") if @show_icon
+      parts << tag.span("(opens in new tab)", class: "sr-only")
+      safe_join(parts)
     end
   end
 end

--- a/app/components/ui/filter_menu_panel_component.rb
+++ b/app/components/ui/filter_menu_panel_component.rb
@@ -22,6 +22,6 @@ class UI::FilterMenuPanelComponent < ViewComponent::Base
   end
 
   def container_classes
-    @more_menu ? "#{CONTAINER_BASE_CLASSES} filter-dropdown-more" : CONTAINER_BASE_CLASSES
+    class_names(CONTAINER_BASE_CLASSES, @more_menu && "filter-dropdown-more")
   end
 end

--- a/app/components/ui/mailto_link_component.rb
+++ b/app/components/ui/mailto_link_component.rb
@@ -1,0 +1,24 @@
+class UI::MailtoLinkComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  BASE_CLASSES = "inline-flex items-center gap-0.5"
+
+  def initialize(email:, show_icon: true, underline: true, classes: nil)
+    raise ArgumentError, "Invalid email: #{email}" unless URI::MailTo::EMAIL_REGEXP.match?(email)
+
+    @email = email
+    @show_icon = show_icon
+    @underline = underline
+    @classes = classes
+  end
+
+  def call
+    tag.a(href: "mailto:#{@email}", class: class_names(BASE_CLASSES, @underline && "underline", @classes)) do
+      parts = []
+      parts << content
+      parts << icon("email", classes: "w-3.5 h-3.5 shrink-0") if @show_icon
+      parts << tag.span("(send email)", class: "sr-only")
+      safe_join(parts)
+    end
+  end
+end

--- a/app/components/ui/map_region_shortcut_button_component.html.erb
+++ b/app/components/ui/map_region_shortcut_button_component.html.erb
@@ -1,7 +1,7 @@
 <%= render UI::CircleButtonComponent.new(
       aria_label: @aria_label,
       data_action: "click->map##{@map_action}",
-      extra_classes: "mt-[5px] text-xs"
+      classes: "mt-[5px] text-xs"
     ) do %>
   <%= @label %>
 <% end %>

--- a/app/components/ui/nav_item_component.html.erb
+++ b/app/components/ui/nav_item_component.html.erb
@@ -1,7 +1,7 @@
 <% if link? %>
   <a href="<%= @href %>"
      aria-label="<%= accessible_label %>"
-     class="<%= base_classes %> no-underline"
+     class="<%= base_classes %> <%= (@external || mailto?) ? nil : "no-underline" %>"
      <% if @external %>
        title="Opens in new tab"
        target="_blank"
@@ -18,7 +18,7 @@
 <% else %>
   <button type="button"
           aria-label="<%= accessible_label %>"
-          <% if @section %>data-section="<%= @section %>" data-action="click->nav#show"<% end %>
+          <% if @section %> data-section="<%= @section %>" data-action="click->nav#show"<% end %>
           class="<%= base_classes %>"
           <% if @active %> aria-current="page"<% end %>>
     <%= icon @icon_name, classes: "h-[18px] w-[18px] shrink-0" %>

--- a/app/components/ui/nav_item_component.html.erb
+++ b/app/components/ui/nav_item_component.html.erb
@@ -1,7 +1,7 @@
 <% if link? %>
   <a href="<%= @href %>"
      aria-label="<%= accessible_label %>"
-     class="<%= base_classes %> <%= (@external || mailto?) ? nil : "no-underline" %>"
+     class="<%= link_classes %>"
      <% if @external %>
        title="Opens in new tab"
        target="_blank"
@@ -13,6 +13,9 @@
     <% if @external %>
       <%= icon "external-link", classes: "inline ml-1 group-data-[sidebar-collapsed]:hidden" %>
       <span class="sr-only">(opens in new tab)</span>
+    <% elsif mailto? %>
+      <%= icon "email", classes: "inline ml-1 group-data-[sidebar-collapsed]:hidden" %>
+      <span class="sr-only">(send email)</span>
     <% end %>
   </a>
 <% else %>

--- a/app/components/ui/nav_item_component.rb
+++ b/app/components/ui/nav_item_component.rb
@@ -23,6 +23,10 @@ class UI::NavItemComponent < ViewComponent::Base
     class_names(NAV_ITEM_CLASSES, @active && "active")
   end
 
+  def link_classes
+    class_names(NAV_ITEM_CLASSES, @active && "active", !(@external || mailto?) && "no-underline")
+  end
+
   def accessible_label
     if @external
       "#{@label} (opens in new tab)"
@@ -35,5 +39,9 @@ class UI::NavItemComponent < ViewComponent::Base
 
   def link?
     @href.present?
+  end
+
+  def mailto?
+    @href.to_s.start_with?("mailto:")
   end
 end

--- a/app/components/ui/nav_item_component.rb
+++ b/app/components/ui/nav_item_component.rb
@@ -20,11 +20,17 @@ class UI::NavItemComponent < ViewComponent::Base
   end
 
   def base_classes
-    @active ? "#{NAV_ITEM_CLASSES} active" : NAV_ITEM_CLASSES
+    class_names(NAV_ITEM_CLASSES, @active && "active")
   end
 
   def accessible_label
-    @external ? "#{@label} (opens in new tab)" : @label
+    if @external
+      "#{@label} (opens in new tab)"
+    elsif mailto?
+      "#{@label} (send email)"
+    else
+      @label
+    end
   end
 
   def link?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,16 +38,6 @@ module ApplicationHelper
   def filter_row_classes = FILTER_ROW_CLASSES
   def download_states = DOWNLOAD_STATES
 
-  def external_link_to(text, url, **html_options)
-    link_to url, target: "_blank", rel: "noopener noreferrer", title: "Opens in new tab", **html_options do
-      safe_join([
-        text,
-        icon("external-link", classes: "w-3.5 h-3.5 shrink-0"),
-        content_tag(:span, "(opens in new tab)", class: "sr-only")
-      ])
-    end
-  end
-
   def icon(name, classes: nil, aria_hidden: true)
     safe_name = name.to_s.gsub(/[^a-z0-9\-_]/, "")
     svg = ICON_CACHE[safe_name]

--- a/app/views/home/_datasets.html.erb
+++ b/app/views/home/_datasets.html.erb
@@ -16,7 +16,13 @@
           This inventory of drinking water datasets includes information from various public data providers.
           You can learn details about specific sources and considerations for use below.
           Please visit the
-          <%= external_link_to "documentation", "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf", class: "inline-flex items-center gap-0.5 text-brand-primary underline" %>
+          <a href="https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf"
+             target="_blank" rel="noopener noreferrer"
+             title="Opens in new tab"
+             class="inline-flex items-center gap-0.5 text-brand-primary underline">documentation
+            <%= icon "external-link", classes: "w-3.5 h-3.5 shrink-0" %>
+            <span class="sr-only">(opens in new tab)</span>
+          </a>
           for additional information and caveats.
         </p>
       </div>

--- a/app/views/home/_datasets.html.erb
+++ b/app/views/home/_datasets.html.erb
@@ -16,13 +16,7 @@
           This inventory of drinking water datasets includes information from various public data providers.
           You can learn details about specific sources and considerations for use below.
           Please visit the
-          <a href="https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf"
-             target="_blank" rel="noopener noreferrer"
-             title="Opens in new tab"
-             class="inline-flex items-center gap-0.5 text-brand-primary underline">documentation
-            <%= icon "external-link", classes: "w-3.5 h-3.5 shrink-0" %>
-            <span class="sr-only">(opens in new tab)</span>
-          </a>
+          <%= render UI::ExternalLinkComponent.new(url: "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf", classes: "text-brand-primary") do %>documentation<% end %>
           for additional information and caveats.
         </p>
       </div>

--- a/app/views/home/_downloads.html.erb
+++ b/app/views/home/_downloads.html.erb
@@ -9,8 +9,7 @@
     <li class="mb-2">Please refer to the README.txt in the download for additional details on the datasets contained and their limitations.</li>
   </ul>
   <p class="mb-6">Have questions about the data? Fill out our
-    <%= external_link_to "feedback form", "https://docs.google.com/forms/d/15GExM4tPoErkbLW43CkNNB2t27SZ7wvPcTwG5IzN5S4/edit",
-        class: "inline-flex items-center gap-0.5 text-black font-bold" %>
+    <%= render UI::ExternalLinkComponent.new(url: "https://docs.google.com/forms/d/15GExM4tPoErkbLW43CkNNB2t27SZ7wvPcTwG5IzN5S4/edit", classes: "text-black font-bold") do %>feedback form<% end %>
     or get in touch via email <a href="mailto:watertool@policyinnovation.org" class="text-black font-bold">watertool@policyinnovation.org</a>.</p>
 
   <div class="border-t border-gray-200 pt-6">

--- a/app/views/home/_downloads.html.erb
+++ b/app/views/home/_downloads.html.erb
@@ -10,7 +10,7 @@
   </ul>
   <p class="mb-6">Have questions about the data? Fill out our
     <%= render UI::ExternalLinkComponent.new(url: "https://docs.google.com/forms/d/15GExM4tPoErkbLW43CkNNB2t27SZ7wvPcTwG5IzN5S4/edit", classes: "text-black font-bold") do %>feedback form<% end %>
-    or get in touch via email <a href="mailto:watertool@policyinnovation.org" class="text-black font-bold">watertool@policyinnovation.org</a>.</p>
+    or get in touch via email <%= render UI::MailtoLinkComponent.new(email: "watertool@policyinnovation.org", classes: "text-black font-bold") do %>watertool@policyinnovation.org<% end %>.</p>
 
   <div class="border-t border-gray-200 pt-6">
     <div class="mb-4">

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -7,7 +7,7 @@
         id: "sidebar-toggle-button",
         aria_label: "Toggle sidebar width",
         data_action: "click->sidebar#toggle",
-        extra_classes: "absolute top-2.5 right-2.5"
+        classes: "absolute top-2.5 right-2.5"
       ) do %>
     <%= icon "collapse", classes: "h-4 w-4 group-data-[sidebar-collapsed]:hidden" %>
     <%= icon "expand", classes: "h-4 w-4 group-[&:not([data-sidebar-collapsed])]:hidden" %>
@@ -53,16 +53,10 @@
     </p>
     <div class="my-6 space-y-2">
       <p>
-        <a href="https://github.com/Environmental-Policy-Innovation-Center/national-dw-tool-public"
-           target="_blank"
-           rel="noopener noreferrer"
-           title="Opens in new tab">Github<%= icon "external-link", classes: "inline ml-0.5" %><span class="sr-only">(opens in new tab)</span></a>
+        <%= render UI::ExternalLinkComponent.new(url: "https://github.com/Environmental-Policy-Innovation-Center/national-dw-tool-public") do %>Github<% end %>
       </p>
       <p>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdj-JcAmFNHnyEGoou74kyL_R1YOUtsFG4dKlYl0TWWwkUcrg/viewform"
-           target="_blank"
-           rel="noopener noreferrer"
-           title="Opens in new tab">Feedback<%= icon "external-link", classes: "inline ml-0.5" %><span class="sr-only">(opens in new tab)</span></a>
+        <%= render UI::ExternalLinkComponent.new(url: "https://docs.google.com/forms/d/e/1FAIpQLSdj-JcAmFNHnyEGoou74kyL_R1YOUtsFG4dKlYl0TWWwkUcrg/viewform") do %>Feedback<% end %>
       </p>
       <p>
         <a href="mailto:watertool@policyinnovation.org"

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -48,7 +48,7 @@
       <%= icon "epic", classes: "mx-auto block w-9 h-auto" %>
     </div>
     <p class="mt-2">
-      (<%= render UI::ExternalLinkComponent.new(url: "https://creativecommons.org/share-your-work/cclicenses/", aria_label: "Creative Commons license (opens in new tab)") do %>cc<% end %>)
+      (<%= render UI::ExternalLinkComponent.new(url: "https://creativecommons.org/share-your-work/cclicenses/") do %><span class="sr-only">Creative Commons license</span><span aria-hidden="true">cc</span><% end %>)
       <span>Environmental Policy<br>Center </span>(EPIC)
     </p>
     <div class="my-6 space-y-2">

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -59,10 +59,7 @@
         <%= render UI::ExternalLinkComponent.new(url: "https://docs.google.com/forms/d/e/1FAIpQLSdj-JcAmFNHnyEGoou74kyL_R1YOUtsFG4dKlYl0TWWwkUcrg/viewform") do %>Feedback<% end %>
       </p>
       <p>
-        <a href="mailto:watertool@policyinnovation.org"
-           class="inline-flex items-center gap-1">Contact EPIC
-          <%= icon "email", classes: "w-3.5 h-3.5 shrink-0" %>
-        </a>
+        <%= render UI::MailtoLinkComponent.new(email: "watertool@policyinnovation.org") do %>Contact EPIC<% end %>
       </p>
     </div>
     <% if @last_updated %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -261,7 +261,7 @@
   <% if @last_updated %>
     <p class="text-white m-0 text-[0.9em]">Latest data update on <%= @last_updated.in_time_zone("Eastern Time (US & Canada)").strftime("%m/%d/%Y at %I:%M %p %Z") %></p>
   <% end %>
-  <p class="text-white m-0 text-[0.9em]">(<%= render UI::ExternalLinkComponent.new(url: "https://creativecommons.org/share-your-work/cclicenses/", aria_label: "Creative Commons license (opens in new tab)", css_class: "text-white inline-flex items-center gap-0.5") do %>cc<%= icon "external-link", classes: "w-3 h-3" %><% end %>) Environmental Policy Innovation Center (EPIC)</p>
+  <p class="text-white m-0 text-[0.9em]">(<%= render UI::ExternalLinkComponent.new(url: "https://creativecommons.org/share-your-work/cclicenses/", classes: "text-white") do %><span class="sr-only">Creative Commons license</span><span aria-hidden="true">cc</span><% end %>) Environmental Policy Innovation Center (EPIC)</p>
 </div>
 
 <%# Mobile menu overlay %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -105,14 +105,14 @@
     <%= render UI::CircleButtonComponent.new(
           aria_label: "Toggle map filters",
           data_action: "click->nav#toggleMobileFilters",
-          extra_classes: "!w-12 !h-12 shadow-sm"
+          classes: "!w-12 !h-12 shadow-sm"
         ) do %>
       <%= icon "map-filters", classes: "w-6 h-6" %>
     <% end %>
     <%= render UI::CircleButtonComponent.new(
           aria_label: "Toggle statistics panel",
           data_action: "click->nav#toggleMobileStats",
-          extra_classes: "!w-12 !h-12 shadow-sm"
+          classes: "!w-12 !h-12 shadow-sm"
         ) do %>
       <%= icon "info", classes: "w-6 h-6" %>
     <% end %>
@@ -233,7 +233,7 @@
         id: "tt-print-report",
         aria_label: "Print report",
         data_action: "click->report#print",
-        extra_classes: "fixed top-[30px] right-20 print:hidden"
+        classes: "fixed top-[30px] right-20 print:hidden"
       ) do %>
     <%= icon "print", classes: "h-4 w-4" %>
   <% end %>
@@ -241,7 +241,7 @@
         id: "tt-close-report",
         aria_label: "Close report",
         data_action: "click->report#close",
-        extra_classes: "fixed top-[30px] right-5 print:hidden"
+        classes: "fixed top-[30px] right-5 print:hidden"
       ) do %><%= icon "close", classes: "h-4 w-4" %><% end %>
 
   <div class="mx-auto max-w-[1200px] border border-[#eee] bg-white p-10 mt-[30px] mb-[50px] print:border-0 print:p-0 print:mt-0 print:mb-0">

--- a/spec/components/ui/circle_button_component_spec.rb
+++ b/spec/components/ui/circle_button_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UI::CircleButtonComponent, type: :component do
         aria_label: "Print",
         id: "tt-print-report",
         data_action: "click->report#print",
-        extra_classes: "fixed top-[30px] right-20"
+        classes: "fixed top-[30px] right-20"
       )
     end
 
@@ -56,13 +56,10 @@ RSpec.describe UI::CircleButtonComponent, type: :component do
       expect(btn["data-action"]).to eq("click->report#print")
     end
 
-    it "appends extra_classes to base classes" do
+    it "merges classes with base classes" do
       render_inline(component) { "" }
       cls = html.at_css("button")["class"]
-      expect(cls).to include("fixed")
-      expect(cls).to include("top-[30px]")
-      expect(cls).to include("right-20")
-      expect(cls).to include("w-8")
+      expect(cls).to include("fixed", "top-[30px]", "right-20", "w-8")
     end
   end
 end

--- a/spec/components/ui/download_link_component_spec.rb
+++ b/spec/components/ui/download_link_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe UI::DownloadLinkComponent, type: :component do
 
   it "includes sr-only download text" do
     render_inline(component) { "National" }
-    expect(html.at_css(".sr-only").text).to eq("(download)")
+    expect(html.at_css(".sr-only").text).to eq("(downloads file)")
   end
 
   it "yields content inside the anchor" do

--- a/spec/components/ui/download_link_component_spec.rb
+++ b/spec/components/ui/download_link_component_spec.rb
@@ -50,12 +50,17 @@ RSpec.describe UI::DownloadLinkComponent, type: :component do
     end
   end
 
-  context "with custom css_class" do
-    subject(:component) { described_class.new(url: "https://example.com/file.zip", css_class: "text-blue-600") }
+  it "always applies structural base classes" do
+    render_inline(component) { "National" }
+    expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "gap-1.5")
+  end
 
-    it "applies the custom class" do
+  context "with custom classes" do
+    subject(:component) { described_class.new(url: "https://example.com/file.zip", classes: "text-blue-600") }
+
+    it "merges custom classes with base classes" do
       render_inline(component) { "National" }
-      expect(html.at_css("a")["class"]).to eq("text-blue-600")
+      expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "text-blue-600")
     end
   end
 end

--- a/spec/components/ui/external_link_component_spec.rb
+++ b/spec/components/ui/external_link_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UI::ExternalLinkComponent, type: :component do
     expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "gap-0.5")
   end
 
-  it "is always underlined" do
+  it "is underlined by default" do
     render_inline(component) { "Example" }
     expect(html.at_css("a")["class"]).to include("underline")
   end
@@ -55,6 +55,20 @@ RSpec.describe UI::ExternalLinkComponent, type: :component do
     it "omits the icon" do
       render_inline(component) { "Example" }
       expect(html.at_css("a svg")).to be_nil
+    end
+  end
+
+  context "with underline: false" do
+    subject(:component) { described_class.new(url: "https://example.com", underline: false) }
+
+    it "omits the underline class" do
+      render_inline(component) { "Example" }
+      expect(html.at_css("a")["class"].split).not_to include("underline")
+    end
+
+    it "retains structural classes" do
+      render_inline(component) { "Example" }
+      expect(html.at_css("a")["class"]).to include("inline-flex", "items-center")
     end
   end
 

--- a/spec/components/ui/external_link_component_spec.rb
+++ b/spec/components/ui/external_link_component_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe UI::ExternalLinkComponent, type: :component do
     expect(html.at_css("a")["title"]).to eq("Opens in new tab")
   end
 
+  it "always applies structural base classes" do
+    render_inline(component) { "Example" }
+    expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "gap-0.5")
+  end
+
   it "is underlined by default" do
     render_inline(component) { "Example" }
     expect(html.at_css("a")["class"]).to include("underline")
@@ -34,28 +39,31 @@ RSpec.describe UI::ExternalLinkComponent, type: :component do
     expect(html.at_css(".sr-only").text).to eq("(opens in new tab)")
   end
 
-  context "with aria_label" do
-    subject(:component) { described_class.new(url: "https://example.com", aria_label: "Example site (opens in new tab)") }
+  it "does not set aria-label" do
+    render_inline(component) { "Example" }
+    expect(html.at_css("a")["aria-label"]).to be_nil
+  end
 
-    it "sets the aria-label" do
+  it "renders the external-link icon by default" do
+    render_inline(component) { "Example" }
+    expect(html.at_css("a svg")).to be_present
+  end
+
+  context "with show_icon: false" do
+    subject(:component) { described_class.new(url: "https://example.com", show_icon: false) }
+
+    it "omits the icon" do
       render_inline(component) { "Example" }
-      expect(html.at_css("a")["aria-label"]).to eq("Example site (opens in new tab)")
+      expect(html.at_css("a svg")).to be_nil
     end
   end
 
-  context "without aria_label" do
-    it "omits the aria-label attribute" do
-      render_inline(component) { "Example" }
-      expect(html.at_css("a")["aria-label"]).to be_nil
-    end
-  end
+  context "with custom classes" do
+    subject(:component) { described_class.new(url: "https://example.com", classes: "text-blue-600") }
 
-  context "with custom css_class" do
-    subject(:component) { described_class.new(url: "https://example.com", css_class: "text-blue-600 underline") }
-
-    it "applies the custom class" do
+    it "merges custom class with base classes" do
       render_inline(component) { "Example" }
-      expect(html.at_css("a")["class"]).to eq("text-blue-600 underline")
+      expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "gap-0.5", "text-blue-600")
     end
   end
 end

--- a/spec/components/ui/external_link_component_spec.rb
+++ b/spec/components/ui/external_link_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UI::ExternalLinkComponent, type: :component do
     expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "gap-0.5")
   end
 
-  it "is underlined by default" do
+  it "is always underlined" do
     render_inline(component) { "Example" }
     expect(html.at_css("a")["class"]).to include("underline")
   end

--- a/spec/components/ui/mailto_link_component_spec.rb
+++ b/spec/components/ui/mailto_link_component_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe UI::MailtoLinkComponent, type: :component do
+  subject(:component) { described_class.new(email: "hello@example.com") }
+
+  it "renders an anchor with a mailto href" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css("a")["href"]).to eq("mailto:hello@example.com")
+  end
+
+  it "always applies structural base classes" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "gap-0.5")
+  end
+
+  it "is underlined by default" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css("a")["class"]).to include("underline")
+  end
+
+  it "yields content inside the anchor" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css("a").text).to include("Contact us")
+  end
+
+  it "includes sr-only send-email text" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css(".sr-only").text).to eq("(send email)")
+  end
+
+  it "does not set aria-label" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css("a")["aria-label"]).to be_nil
+  end
+
+  it "renders the email icon by default" do
+    render_inline(component) { "Contact us" }
+    expect(html.at_css("a svg")).to be_present
+  end
+
+  context "with show_icon: false" do
+    subject(:component) { described_class.new(email: "hello@example.com", show_icon: false) }
+
+    it "omits the icon" do
+      render_inline(component) { "Contact us" }
+      expect(html.at_css("a svg")).to be_nil
+    end
+  end
+
+  context "with underline: false" do
+    subject(:component) { described_class.new(email: "hello@example.com", underline: false) }
+
+    it "omits the underline class" do
+      render_inline(component) { "Contact us" }
+      expect(html.at_css("a")["class"].split).not_to include("underline")
+    end
+
+    it "retains structural classes" do
+      render_inline(component) { "Contact us" }
+      expect(html.at_css("a")["class"]).to include("inline-flex", "items-center")
+    end
+  end
+
+  context "with an invalid email" do
+    it "raises ArgumentError" do
+      expect {
+        described_class.new(email: "not-an-email")
+      }.to raise_error(ArgumentError, /Invalid email/)
+    end
+  end
+
+  context "with custom classes" do
+    subject(:component) { described_class.new(email: "hello@example.com", classes: "text-black font-bold underline") }
+
+    it "merges custom classes with base classes" do
+      render_inline(component) { "Contact us" }
+      expect(html.at_css("a")["class"]).to include("inline-flex", "items-center", "text-black", "underline")
+    end
+  end
+end

--- a/spec/components/ui/nav_item_component_spec.rb
+++ b/spec/components/ui/nav_item_component_spec.rb
@@ -115,6 +115,48 @@ RSpec.describe UI::NavItemComponent, type: :component do
     end
   end
 
+  describe "mailto link variant" do
+    subject do
+      render_inline described_class.new(
+        label: "Contact Us",
+        icon_name: "email",
+        href: "mailto:contact@example.com"
+      )
+    end
+
+    it "renders an anchor with the mailto href" do
+      subject
+      expect(html.css("a").first["href"]).to eq("mailto:contact@example.com")
+    end
+
+    it "appends (send email) to aria-label" do
+      subject
+      expect(html.css("a").first["aria-label"]).to eq("Contact Us (send email)")
+    end
+
+    it "does not include no-underline class" do
+      subject
+      expect(html.css("a").first["class"].split).not_to include("no-underline")
+    end
+
+    it "renders a sr-only span disclosing the email action" do
+      subject
+      sr = html.css(".sr-only").first
+      expect(sr).to be_present
+      expect(sr.text).to include("send email")
+    end
+
+    it "renders the email icon" do
+      subject
+      expect(html.to_html).to include("email")
+    end
+
+    it "does not add target=_blank" do
+      subject
+      expect(html.css("a").first["target"]).to be_nil
+    end
+  end
+
   describe "external: true" do
     subject do
       render_inline described_class.new(


### PR DESCRIPTION
## Summary

Creates two new **ViewComponent** objects: `ExternalLinkComponent` and `DownloadLinkComponent`, and wraps existing links in these new components.

### Issue
- [Add external link icons to all externally linked data sources on the datasets page](https://github.com/Environmental-Policy-Innovation-Center/water-data-tool/issues/122)


### Notes

Test Notes:

Sidebar (desktop, hidden on mobile)
- Documentation PDF — nav item
- GitHub — bottom of sidebar
- Feedback form — bottom of sidebar
- CC license — bottom of sidebar

Datasets section
- "Recommend Datasets" button — top of datasets panel
- Data source link — on every dataset card (30+ links, one per card)
- Downloads section

Feedback form — intro paragraph
- National download — standalone link
- State/territory downloads — grid of ~56 links

Mobile menu (hamburger, visible below 640px)
_(Mobile styling is very much in progress and this is a known TODO item)_
- Documentation PDF — nav item
- GitHub — nav item
- Feedback form — nav item
- CC license — footer of mobile menu