### PR TITLE
[CI] Register 'pr-previews' environment for visibility

### DIFF
--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -137,6 +137,67 @@ jobs:
             --port 5432 \
             --source-group "$NODE_SG_ID" || true
 
+      - name: Wait until latest deployment is reachable
+        run: |
+          TARGET_IMAGE="${{ env.ECR_REPO_URI }}:pr-${{ env.PR_NUM }}-${{ github.sha }}"
+          PR_URL="https://water-data-tool-pr-${{ env.PR_NUM }}.policyinnovation.info/up"
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+          IMAGE_FOUND=false
+
+          echo "Resolving ECS service ARN for PR ${{ env.PR_NUM }}..."
+          SERVICE_ARN=$(aws ecs list-services \
+            --cluster "$ECS_CLUSTER" \
+            --output text \
+            | tr '\t' '\n' \
+            | grep "water_data_tool_pr_${{ env.PR_NUM }}")
+          echo "Service ARN: $SERVICE_ARN"
+
+          echo "Phase 1: waiting for ECS to run image $TARGET_IMAGE (up to 15 min)..."
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            TASK_ARNS=$(aws ecs list-tasks \
+              --cluster "$ECS_CLUSTER" \
+              --service-name "$SERVICE_ARN" \
+              --desired-status RUNNING \
+              --query 'taskArns' --output json 2>/dev/null || echo "[]")
+            if [ "$(echo "$TASK_ARNS" | jq 'length')" -gt 0 ]; then
+              IMAGES=$(aws ecs describe-tasks \
+                --cluster "$ECS_CLUSTER" \
+                --tasks $(echo "$TASK_ARNS" | jq -r '.[]') \
+                --query 'tasks[*].containers[*].image' \
+                --output json)
+              if echo "$IMAGES" | jq -e --arg img "$TARGET_IMAGE" 'flatten | any(. == $img)' > /dev/null; then
+                echo "[$ATTEMPT/$MAX_ATTEMPTS] New image confirmed running."
+                IMAGE_FOUND=true
+                break
+              fi
+            else
+              echo "[$ATTEMPT/$MAX_ATTEMPTS] No running tasks yet, waiting..."
+            fi
+            sleep 15
+          done
+          if [ "$IMAGE_FOUND" != "true" ]; then
+            echo "ERROR: timed out after 15 minutes waiting for new image to start."
+            exit 1
+          fi
+
+          ATTEMPT=0
+          MAX_ATTEMPTS=20
+          echo "Phase 2: polling $PR_URL until HTTP 200 (up to 5 min)..."
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 "$PR_URL" || echo "000")
+            echo "[$ATTEMPT/$MAX_ATTEMPTS] HTTP $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "Service is healthy."
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "ERROR: new image is running but $PR_URL did not return 200 within 5 minutes."
+          exit 1
+
       - name: Comment URL on PR
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -17,10 +17,14 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action != 'closed'
     runs-on: ubuntu-latest
+    environment:
+      name: pr-previews
+      url: https://water-data-tool-pr-${{ github.event.number }}.policyinnovation.info/
     permissions:
       id-token: write
       contents: read
       pull-requests: write
+      deployments: write
     env:
       AWS_REGION:      ${{ vars.AWS_REGION }}
       ECR_REPO_URI:    ${{ vars.ECR_REPO_URI }}
@@ -157,10 +161,13 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action == 'closed'
     runs-on: ubuntu-latest
+    environment:
+      name: pr-previews
     permissions:
       id-token: write
       contents: read
       pull-requests: write
+      deployments: write
     env:
       AWS_REGION:            ${{ vars.AWS_REGION }}
       ECS_CLUSTER:           ${{ vars.ECS_CLUSTER }}

--- a/.github/workflows/list-pr-environments.yml
+++ b/.github/workflows/list-pr-environments.yml
@@ -1,0 +1,150 @@
+name: List PR Environments
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: list-pr-environments
+  cancel-in-progress: true
+
+jobs:
+  list:
+    if: vars.AWS_DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: pr-previews
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+    env:
+      AWS_REGION:   ${{ vars.AWS_REGION }}
+      ECS_CLUSTER:  ${{ vars.ECS_CLUSTER }}
+      ECR_REPO_URI: ${{ vars.ECR_REPO_URI }}
+
+    steps:
+      - name: Configure AWS credentials (PR role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PR_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: List deployed PR environments
+        id: list
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          ECR_REPO_NAME="${ECR_REPO_URI##*/}"
+
+          # Collect all ECS service ARNs (paginated)
+          SERVICE_ARNS=""
+          NEXT_TOKEN=""
+          while true; do
+            if [[ -z "$NEXT_TOKEN" ]]; then
+              PAGE=$(aws ecs list-services --cluster "$ECS_CLUSTER" --output json)
+            else
+              PAGE=$(aws ecs list-services \
+                --cluster "$ECS_CLUSTER" \
+                --starting-token "$NEXT_TOKEN" \
+                --output json)
+            fi
+
+            ARNS=$(echo "$PAGE" | jq -r '.serviceArns[]?')
+            if [[ -n "$ARNS" ]]; then
+              SERVICE_ARNS+=$'\n'"$ARNS"
+            fi
+
+            NEXT_TOKEN=$(echo "$PAGE" | jq -r '.nextToken // empty')
+            [[ -z "$NEXT_TOKEN" ]] && break
+          done
+
+          PR_NUMS=$(echo "$SERVICE_ARNS" \
+            | tr '\t' '\n' \
+            | grep -E 'water_data_tool_pr_[0-9]+$' || true \
+            | sed 's|.*/water_data_tool_pr_||' \
+            | sort -n \
+            | uniq)
+
+          if [[ -z "$PR_NUMS" ]]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No PR preview environments found in ECS cluster \`$ECS_CLUSTER\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Describe ECS services in batches of 10
+          declare -A RUNNING DESIRED ECS_DEPLOYED
+          BATCH=()
+          flush_batch() {
+            [[ ${#BATCH[@]} -eq 0 ]] && return
+            readarray -t DESCRIBED < <(aws ecs describe-services \
+              --cluster "$ECS_CLUSTER" \
+              --services "${BATCH[@]}" \
+              --query 'services[*].{name:serviceName,running:runningCount,desired:desiredCount,deployed:deployments[0].createdAt}' \
+              --output json \
+              | jq -c '.[]')
+            for row in "${DESCRIBED[@]}"; do
+              name=$(echo "$row" | jq -r '.name')
+              n="${name#water_data_tool_pr_}"
+              RUNNING[$n]=$(echo "$row" | jq -r '.running')
+              DESIRED[$n]=$(echo "$row" | jq -r '.desired')
+              ECS_DEPLOYED[$n]=$(echo "$row" | jq -r '.deployed // empty')
+            done
+            BATCH=()
+          }
+
+          for PR_NUM in $PR_NUMS; do
+            BATCH+=("water_data_tool_pr_${PR_NUM}")
+            if [[ ${#BATCH[@]} -eq 10 ]]; then
+              flush_batch
+            fi
+          done
+          flush_batch
+
+          # Build markdown table
+          {
+            echo "## PR preview environments"
+            echo ""
+            echo "| PR | Title | URL | Last image push (UTC) | ECS rollout (UTC) | Tasks | PR state |"
+            echo "|---:|---|---|---|---|---:|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          COUNT=0
+          for PR_NUM in $PR_NUMS; do
+            URL="https://water-data-tool-pr-${PR_NUM}.policyinnovation.info/"
+
+            PUSHED=$(aws ecr describe-images \
+              --repository-name "$ECR_REPO_NAME" \
+              --image-ids "imageTag=pr-${PR_NUM}-latest" \
+              --query 'imageDetails[0].imagePushedAt' \
+              --output text 2>/dev/null || echo "")
+            [[ "$PUSHED" == "None" || -z "$PUSHED" ]] && PUSHED="—"
+
+            ECS_AT="${ECS_DEPLOYED[$PR_NUM]:-—}"
+            RUN="${RUNNING[$PR_NUM]:-0}"
+            WANT="${DESIRED[$PR_NUM]:-0}"
+
+            TITLE="—"
+            STATE="—"
+            if PR_JSON=$(gh pr view "$PR_NUM" --json title,state 2>/dev/null); then
+              TITLE=$(echo "$PR_JSON" | jq -r '.title' | tr '|' '/')
+              STATE=$(echo "$PR_JSON" | jq -r '.state')
+            else
+              STATE="not found"
+            fi
+
+            echo "| #${PR_NUM} | ${TITLE} | [${URL}](${URL}) | ${PUSHED} | ${ECS_AT} | ${RUN}/${WANT} | ${STATE} |" \
+              >> "$GITHUB_STEP_SUMMARY"
+            COUNT=$((COUNT + 1))
+          done
+
+          {
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Environments listed** | ${COUNT} |"
+            echo "| **Triggered by** | @${{ github.actor }} |"
+            echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale pull requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has had no activity for 3 weeks and will be closed in 7 days.
+            Push a commit or leave a comment to keep it open.
+          close-pr-message: >
+            Closed due to 4 weeks of inactivity. Reopen and push a commit to
+            redeploy the preview environment.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.github/workflows/teardown-pr-envs.yml
+++ b/.github/workflows/teardown-pr-envs.yml
@@ -1,0 +1,168 @@
+name: Teardown PR Environments
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: '"specific" to destroy one PR, "stale" to sweep by last-commit age'
+        required: true
+        type: choice
+        options: [specific, stale]
+      pr_number:
+        description: 'PR number to destroy (mode=specific only)'
+        required: false
+      days_old:
+        description: 'Destroy PRs with no new commits in this many days (mode=stale only) - default: 14'
+        required: false
+        default: '14'
+      confirm:
+        description: 'Type "teardown" to confirm'
+        required: true
+
+concurrency:
+  group: teardown-pr-envs
+  cancel-in-progress: false
+
+jobs:
+  teardown:
+    if: >
+      vars.AWS_DEPLOY_ENABLED == 'true' &&
+      github.event.inputs.confirm == 'teardown'
+    runs-on: ubuntu-latest
+    environment: pr-previews
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      deployments: write
+    env:
+      AWS_REGION:            ${{ vars.AWS_REGION }}
+      ECS_CLUSTER:           ${{ vars.ECS_CLUSTER }}
+      SERVICE_BUILDER_IMAGE: ${{ vars.SERVICE_BUILDER_IMAGE_URI }}
+
+    steps:
+      - name: Validate confirmation input
+        if: github.event.inputs.confirm != 'teardown'
+        run: |
+          echo "::error::Confirmation input must be exactly 'teardown'. Got: '${{ github.event.inputs.confirm }}'"
+          exit 1
+
+      - name: Validate specific mode inputs
+        if: github.event.inputs.mode == 'specific' && github.event.inputs.pr_number == ''
+        run: |
+          echo "::error::pr_number is required when mode=specific"
+          exit 1
+
+      - name: Configure AWS credentials (PR role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PR_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Resolve PR list
+        id: prs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ github.event.inputs.mode }}" == "specific" ]]; then
+            echo "list=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            DAYS="${{ github.event.inputs.days_old }}"
+            CUTOFF=$(date -u -d "${DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ')
+
+            SERVICES=$(aws ecs list-services \
+              --cluster "$ECS_CLUSTER" \
+              --output text \
+              | tr '\t' '\n' \
+              | grep "water_data_tool_pr_" \
+              | sed 's|.*/water_data_tool_pr_||')
+
+            STALE=""
+            for PR_NUM in $SERVICES; do
+              HEAD_SHA=$(gh pr view "$PR_NUM" \
+                --json headRefOid \
+                --jq '.headRefOid' 2>/dev/null || echo "")
+              LAST_COMMIT=""
+              if [[ -n "$HEAD_SHA" ]]; then
+                LAST_COMMIT=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA" \
+                  --jq '.commit.committer.date' 2>/dev/null || echo "")
+              fi
+
+              if [[ -z "$LAST_COMMIT" ]]; then
+                echo "PR #$PR_NUM — not found or closed, marking stale"
+                STALE="$STALE $PR_NUM"
+              elif [[ "$LAST_COMMIT" < "$CUTOFF" ]]; then
+                echo "PR #$PR_NUM — last commit $LAST_COMMIT, stale"
+                STALE="$STALE $PR_NUM"
+              else
+                echo "PR #$PR_NUM — last commit $LAST_COMMIT, still active, skipping"
+              fi
+            done
+
+            echo "list=$(echo $STALE | xargs)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tear down PR environments
+        env:
+          PR_LIST: ${{ steps.prs.outputs.list }}
+        run: |
+          if [[ -z "$PR_LIST" ]]; then
+            echo "No PR environments matched — nothing to tear down."
+            exit 0
+          fi
+
+          for PR_NUM in $PR_LIST; do
+            echo "── Tearing down PR #${PR_NUM} ──"
+
+            NODE_SG_ID=$(aws ec2 describe-security-groups \
+              --filters "Name=group-name,Values=epapp__nodes_water_data_tool_pr_${PR_NUM}__dev_us-east-1" \
+              --query 'SecurityGroups[0].GroupId' --output text)
+            if [ -n "$NODE_SG_ID" ] && [ "$NODE_SG_ID" != "None" ]; then
+              aws ec2 revoke-security-group-ingress \
+                --group-id "${{ vars.RDS_SG_ID }}" \
+                --protocol tcp \
+                --port 5432 \
+                --source-group "$NODE_SG_ID" || true
+            fi
+
+            docker run --rm \
+              -e EP_ACTION=destroy \
+              -e EP_ENV="pr-${PR_NUM}" \
+              -e EP_SERVICE_NAME="water_data_tool_pr_${PR_NUM}" \
+              -e EP_SERVICE_SHORT_NAME="pr${PR_NUM}" \
+              -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
+              -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
+              -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
+              -e EP_SERVICE_INSTANCE_COUNT="1" \
+              -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
+              -e EP_SERVICE_DOMAIN="water-data-tool-pr-${PR_NUM}.policyinnovation.info" \
+              -e EP_SERVICE_PORT="3000" \
+              -e EP_SERVICE_HEALTH_PORT="3000" \
+              -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
+              -e EP_CREATE_ECR_REPO="false" \
+              -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+              -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+              -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+              -e AWS_REGION="$AWS_REGION" \
+              "$SERVICE_BUILDER_IMAGE"
+
+            echo "PR #${PR_NUM} torn down."
+          done
+
+      - name: Summary
+        env:
+          PR_LIST: ${{ steps.prs.outputs.list }}
+        run: |
+          {
+            echo "## PR environment teardown complete"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Mode** | ${{ github.event.inputs.mode }} |"
+            echo "| **PRs torn down** | \`$(echo $PR_LIST | tr ' ' ', ')\` |"
+            echo "| **Triggered by** | @${{ github.actor }} |"
+            echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/teardown-pr-envs.yml
+++ b/.github/workflows/teardown-pr-envs.yml
@@ -33,7 +33,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: write
       deployments: write
     env:
       AWS_REGION:            ${{ vars.AWS_REGION }}
@@ -41,12 +40,6 @@ jobs:
       SERVICE_BUILDER_IMAGE: ${{ vars.SERVICE_BUILDER_IMAGE_URI }}
 
     steps:
-      - name: Validate confirmation input
-        if: github.event.inputs.confirm != 'teardown'
-        run: |
-          echo "::error::Confirmation input must be exactly 'teardown'. Got: '${{ github.event.inputs.confirm }}'"
-          exit 1
-
       - name: Validate specific mode inputs
         if: github.event.inputs.mode == 'specific' && github.event.inputs.pr_number == ''
         run: |
@@ -58,9 +51,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_PR_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Resolve PR list
         id: prs
@@ -102,7 +92,7 @@ jobs:
               fi
             done
 
-            echo "list=$(echo $STALE | xargs)" >> "$GITHUB_OUTPUT"
+            echo "list=$(echo "$STALE" | xargs)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Tear down PR environments
@@ -162,7 +152,7 @@ jobs:
             echo "| | |"
             echo "|---|---|"
             echo "| **Mode** | ${{ github.event.inputs.mode }} |"
-            echo "| **PRs torn down** | \`$(echo $PR_LIST | tr ' ' ', ')\` |"
+            echo "| **PRs torn down** | \`$(echo "$PR_LIST" | tr ' ' ', ')\` |"
             echo "| **Triggered by** | @${{ github.actor }} |"
             echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ Built for [EPIC](https://www.policyinnovation.org/) (Environmental Policy Innova
 - `ETL_SOURCE_URL` env var — the base HTTPS URL to the S3 folder containing source data files. Required to seed the database. Get this value from the project team and add it to your `.env` before running `bin/setup`.
 
 
-## Current Deployed Instances (example values)
-- **Staging**: https://apps.cnt.org/water-data-tool-staging/
-- **Production**: https://apps.cnt.org/water-data-tool/
-
-These URLs reflect the current hosting environment and should be replaced during ownership transfer.
+## Current Deployed Instances
+- **Production**: https://water-data-tool.policyinnovation.info
+- **Staging**: https://water-data-tool-staging.policyinnovation.info
+- **PR previews**: https://water-data-tool-pr-\<N\>.policyinnovation.info (spun up automatically for each open PR)
 
 ---
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -62,7 +62,7 @@ When a PR is opened or updated against `main`:
 
 When the PR is closed, `service_builder` runs with `EP_ACTION=destroy` and tears down all provisioned resources.
 
-> **Stale environments:** Teardown only fires on PR close. If teardown fails, the environment persists. Terraform state is preserved in S3 at `tf/water_data_tool_pr_<N>/water_data_tool_pr_<N>_pr-<N>.tfstate`. Re-run the teardown job in GitHub Actions, or run `terraform destroy` locally using that state file.
+> **Stale environments:** Teardown only fires on PR close. If teardown fails, the environment persists. Terraform state is preserved in S3 at `tf/water_data_tool_pr_<N>/water_data_tool_pr_<N>_pr-<N>.tfstate`. Use the **Teardown PR Environments** workflow to clean up manually, or run `terraform destroy` locally using that state file.
 
 ---
 
@@ -81,6 +81,24 @@ When the PR is closed, `service_builder` runs with `EP_ACTION=destroy` and tears
 3. Click **Run workflow**
 
 Watch progress in the **Actions** tab. Both workflows write a summary table (image digest, URL, who triggered it) to the job summary on completion.
+
+### Tear down PR environments manually
+
+Use **Actions → Teardown PR Environments → Run workflow** to destroy one or more PR environments on demand. Two modes:
+
+**Specific** — destroy a single PR environment by number:
+1. Set **Mode** to `specific`
+2. Enter the PR number
+3. Type `teardown` in the confirmation field
+4. Click **Run workflow**
+
+**Stale** — sweep all PR environments whose last commit is older than N days:
+1. Set **Mode** to `stale`
+2. Optionally set **Days old** (default: 14)
+3. Type `teardown` in the confirmation field
+4. Click **Run workflow**
+
+The stale sweep lists all ECS services matching `water_data_tool_pr_*`, checks each PR's last commit date via the GitHub API, and destroys any that haven't been updated within the threshold. PRs that are already closed or not found are also torn down.
 
 ---
 
@@ -270,12 +288,6 @@ Neither strategy is wired up yet — both are day-two operational items before s
 
 ### Stale PR environment cleanup
 
-PR environments are torn down by the `pr-teardown` job when a PR is closed. If teardown fails, the environment persists indefinitely — there is no age-based sweep.
+PR environments are torn down automatically by the `pr-teardown` job when a PR is closed. If teardown fails, environments can be cleaned up manually using the **Teardown PR Environments** workflow (see [Tear down PR environments manually](#tear-down-pr-environments-manually) above).
 
-**Recommended:** add `.github/workflows/stale-pr-envs.yml` — a scheduled workflow (e.g. nightly) that:
-
-1. Lists all ECS services in the cluster matching `water_data_tool_pr_*`
-2. For each, checks whether the corresponding PR (`#N`) is still open via the GitHub API
-3. If the PR is merged or closed, runs `service_builder` with `EP_ACTION=destroy` to clean it up
-
-This follows the same pattern as the existing `pr-teardown` job and uses the same `AWS_PR_DEPLOY_ROLE_ARN` role — no new IAM permissions needed. It acts as a safety net, not a replacement for the primary teardown trigger.
+A scheduled automatic sweep (e.g. nightly cron) does not exist yet. If stale environments become a recurring problem, the `teardown-pr-envs.yml` workflow could be extended with a `schedule:` trigger using the existing `stale` mode logic.

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -58,6 +58,7 @@ When a PR is opened or updated against `main`:
 2. Secrets Manager ARNs are looked up (`rails_master_key`, `mapbox_access_token`, `mapbox_style_url`, `database_url`).
 3. `service_builder` runs with `EP_ACTION=apply` — this provisions a full ECS service, ALB, Route53 DNS record, and ACM certificate unique to that PR. First provision takes ~5–10 minutes (ACM cert validation).
 4. The environment is available at `https://water-data-tool-pr-<N>.policyinnovation.info`.
+5. GitHub registers a deployment against the shared `pr-previews` environment. The PR timeline shows a **View deployment** button linked to the preview URL. Clicking into `pr-previews` from the repository Deployments sidebar shows all PR deployments with individual URLs and statuses. When a PR is closed, `pr-teardown` marks that specific deployment inactive.
 
 When the PR is closed, `service_builder` runs with `EP_ACTION=destroy` and tears down all provisioned resources.
 
@@ -84,6 +85,12 @@ Watch progress in the **Actions** tab. Both workflows write a summary table (ima
 ---
 
 ## Checking what's currently deployed
+
+### GitHub Environments UI
+
+The fastest way to see what PR environments are live: go to the repository home page on GitHub and click **Deployments** in the right sidebar. This shows `staging`, `production`, and `pr-previews`. Click into `pr-previews` to see every PR deployment — each entry shows its unique preview URL and whether it is currently active or has been torn down.
+
+For a full deployment history (timestamps, who triggered, how long it ran), go to **Settings → Environments** and click into any environment.
 
 ### Health check all environments
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -57,8 +57,13 @@ When a PR is opened or updated against `main`:
 1. The image is built and pushed with `pr-<N>-<sha>` and `pr-<N>-latest` tags.
 2. Secrets Manager ARNs are looked up (`rails_master_key`, `mapbox_access_token`, `mapbox_style_url`, `database_url`).
 3. `service_builder` runs with `EP_ACTION=apply` — this provisions a full ECS service, ALB, Route53 DNS record, and ACM certificate unique to that PR. First provision takes ~5–10 minutes (ACM cert validation).
-4. The environment is available at `https://water-data-tool-pr-<N>.policyinnovation.info`.
-5. GitHub registers a deployment against the shared `pr-previews` environment. The PR timeline shows a **View deployment** button linked to the preview URL. Clicking into `pr-previews` from the repository Deployments sidebar shows all PR deployments with individual URLs and statuses. When a PR is closed, `pr-teardown` marks that specific deployment inactive.
+4. The workflow waits in two phases before posting the PR comment:
+   - **Phase 1** — polls ECS every 15 seconds (up to 15 min) until a running task is confirmed to be using the exact new image SHA. This ensures we are not checking the old container.
+   - **Phase 2** — polls the preview URL's `/up` health check every 15 seconds (up to 5 min) until it returns HTTP 200.
+5. Once both phases pass, the PR comment with the preview URL is posted and GitHub registers the deployment as active.
+6. GitHub registers a deployment against the shared `pr-previews` environment. The PR timeline shows a **View deployment** button linked to the preview URL. Clicking into `pr-previews` from the repository Deployments sidebar shows all PR deployments with individual URLs and statuses. When a PR is closed, `pr-teardown` marks that specific deployment inactive.
+
+> **Why the workflow takes a few minutes after `service_builder` finishes:** The workflow first confirms the new image is running in ECS (up to 15 min), then confirms the URL is returning HTTP 200 (up to 5 min), and only then posts the PR comment. If the job is still running, it is polling — not hung. First-time PR deploys can take 5–10 minutes due to ACM cert validation; subsequent pushes to the same PR typically resolve in 1–3 minutes. If Phase 1 times out, the ECS task failed to start — check CloudWatch logs. If Phase 2 times out, the container started but isn't passing its health check.
 
 When the PR is closed, `service_builder` runs with `EP_ACTION=destroy` and tears down all provisioned resources.
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -105,6 +105,19 @@ Use **Actions → Teardown PR Environments → Run workflow** to destroy one or 
 
 The stale sweep lists all ECS services matching `water_data_tool_pr_*`, checks each PR's last commit date via the GitHub API, and destroys any that haven't been updated within the threshold. PRs that are already closed or not found are also torn down.
 
+### List PR preview environments (AWS + ECR)
+
+Use **Actions → List PR Environments → Run workflow** for a read-only inventory sourced from ECS and ECR (no teardown). The job summary table includes:
+
+- PR number and title (from GitHub, when the PR still exists)
+- Preview URL
+- **Last image push** — `pr-<N>-latest` tag in ECR (`imagePushedAt`)
+- **ECS rollout** — most recent deployment on the ECS service
+- Running vs desired task count
+- PR state (`OPEN`, `CLOSED`, or `not found`)
+
+This complements the **Deployments** sidebar: that UI reflects GitHub deployment records; this workflow reflects what is actually provisioned in AWS.
+
 ---
 
 ## Checking what's currently deployed


### PR DESCRIPTION
## Summary

Wires up the existing AWS ECS PR preview deployments into GitHub's native Environments system so they're visible in the repo UI.

Environment: [pr-previews](https://github.com/Environmental-Policy-Innovation-Center/water-data-tool/deployments/pr-previews)

What changed:
  - `deploy-client-aws.yml` - adds an environment: pr-previews block to the pr-deploy and pr-teardown jobs. GitHub now registers each PR deployment as active on open and inactive on close, with a View deployment link in the PR timeline.
  - `teardown-pr-envs.yml` - new manual workflow for on-demand PR environment cleanup. Supports destroying a single PR by number _(specific mode)_ or sweeping all environments whose last commit exceeds an age threshold (stale mode, default 14 days).
  - `docs/DEPLOYMENTS.md` and `README.md` - updated to document the new GitHub Environments UI, the pr-previews environment, and the manual teardown workflow. Removes the stale cleanup item from Known Gaps.
  - `stale.yml` - a new workflow which handles auto-closing stale PRs, thus tearing down those resources.
  -  Add a new **Waiting until latest deployment available** step in the 'pr-deploy' job, which waits until we get confirmation that the ECS instance has been updated and is reachable - _This allows us to avoid seeing a success message in GitHub, and then getting a 503 at the PR branch URL, if we check it right away._
  - Add a new workflow dispatch _(`List PR Environments`)_ - will need to test once this lands on main.
  
<img width="1279" height="774" alt="Screenshot 2026-05-19 at 3 18 41 PM" src="https://github.com/user-attachments/assets/abd65eb1-5984-4232-ba28-ea0242513031" />
