### PR TITLE
[CI] Move shared PR teardown logic into a composite action

### DIFF
--- a/.github/actions/teardown-pr/action.yml
+++ b/.github/actions/teardown-pr/action.yml
@@ -1,0 +1,51 @@
+name: Teardown PR Environment
+description: Revokes RDS access and destroys the ECS preview environment for a single PR.
+
+inputs:
+  pr_number:
+    description: 'PR number to tear down'
+    required: true
+  rds_sg_id:
+    description: 'RDS security group ID to revoke ingress from'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Remove PR nodes from RDS allowlist
+      shell: bash
+      run: |
+        NODE_SG_ID=$(aws ec2 describe-security-groups \
+          --filters "Name=group-name,Values=epapp__nodes_water_data_tool_pr_${{ inputs.pr_number }}__dev_us-east-1" \
+          --query 'SecurityGroups[0].GroupId' --output text)
+        if [ -n "$NODE_SG_ID" ] && [ "$NODE_SG_ID" != "None" ]; then
+          aws ec2 revoke-security-group-ingress \
+            --group-id "${{ inputs.rds_sg_id }}" \
+            --protocol tcp \
+            --port 5432 \
+            --source-group "$NODE_SG_ID" || true
+        fi
+
+    - name: Destroy PR environment via service_builder
+      shell: bash
+      run: |
+        docker run --rm \
+          -e EP_ACTION=destroy \
+          -e EP_ENV="pr-${{ inputs.pr_number }}" \
+          -e EP_SERVICE_NAME="water_data_tool_pr_${{ inputs.pr_number }}" \
+          -e EP_SERVICE_SHORT_NAME="pr${{ inputs.pr_number }}" \
+          -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
+          -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
+          -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
+          -e EP_SERVICE_INSTANCE_COUNT="1" \
+          -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
+          -e EP_SERVICE_DOMAIN="water-data-tool-pr-${{ inputs.pr_number }}.policyinnovation.info" \
+          -e EP_SERVICE_PORT="3000" \
+          -e EP_SERVICE_HEALTH_PORT="3000" \
+          -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
+          -e EP_CREATE_ECR_REPO="false" \
+          -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+          -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+          -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+          -e AWS_REGION="$AWS_REGION" \
+          "$SERVICE_BUILDER_IMAGE"

--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -235,6 +235,8 @@ jobs:
       PR_NUM:                ${{ github.event.number }}
       SERVICE_BUILDER_IMAGE: ${{ vars.SERVICE_BUILDER_IMAGE_URI }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Configure AWS credentials (PR role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -244,43 +246,11 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Remove PR nodes from RDS allowlist
-        run: |
-          NODE_SG_ID=$(aws ec2 describe-security-groups \
-            --filters "Name=group-name,Values=epapp__nodes_water_data_tool_pr_${{ env.PR_NUM }}__dev_us-east-1" \
-            --query 'SecurityGroups[0].GroupId' --output text)
-          if [ -z "$NODE_SG_ID" ] || [ "$NODE_SG_ID" = "None" ]; then
-            echo "PR node SG not found, nothing to revoke."
-            exit 0
-          fi
-          aws ec2 revoke-security-group-ingress \
-            --group-id "${{ vars.RDS_SG_ID }}" \
-            --protocol tcp \
-            --port 5432 \
-            --source-group "$NODE_SG_ID" || true
-
-      - name: Destroy PR environment via service_builder
-        run: |
-          docker run --rm \
-            -e EP_ACTION=destroy \
-            -e EP_ENV="pr-${{ env.PR_NUM }}" \
-            -e EP_SERVICE_NAME="water_data_tool_pr_${{ env.PR_NUM }}" \
-            -e EP_SERVICE_SHORT_NAME="pr${{ env.PR_NUM }}" \
-            -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
-            -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
-            -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
-            -e EP_SERVICE_INSTANCE_COUNT="1" \
-            -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
-            -e EP_SERVICE_DOMAIN="water-data-tool-pr-${{ env.PR_NUM }}.policyinnovation.info" \
-            -e EP_SERVICE_PORT="3000" \
-            -e EP_SERVICE_HEALTH_PORT="3000" \
-            -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
-            -e EP_CREATE_ECR_REPO="false" \
-            -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-            -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-            -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
-            -e AWS_REGION="$AWS_REGION" \
-            "$SERVICE_BUILDER_IMAGE"
+      - name: Tear down PR environment
+        uses: ./.github/actions/teardown-pr
+        with:
+          pr_number: ${{ env.PR_NUM }}
+          rds_sg_id: ${{ vars.RDS_SG_ID }}
 
       - name: Comment teardown on PR
         env:

--- a/.github/workflows/list-pr-environments.yml
+++ b/.github/workflows/list-pr-environments.yml
@@ -150,7 +150,7 @@ jobs:
             echo "|---|---|"
             echo "| **Environments listed** | ${COUNT} |"
             echo "| **Triggered by** | @${{ github.actor }} |"
-            echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
+            echo "| **Time** | $(TZ='America/New_York' date '+%B %-d, %Y %-I:%M %p %Z') |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/teardown-pr-env.yml
+++ b/.github/workflows/teardown-pr-env.yml
@@ -33,6 +33,8 @@ jobs:
       PR_NUM:                ${{ github.event.inputs.pr_number }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Configure AWS credentials (PR role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -42,41 +44,11 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Remove PR nodes from RDS allowlist
-        run: |
-          NODE_SG_ID=$(aws ec2 describe-security-groups \
-            --filters "Name=group-name,Values=epapp__nodes_water_data_tool_pr_${PR_NUM}__dev_us-east-1" \
-            --query 'SecurityGroups[0].GroupId' --output text)
-          if [ -n "$NODE_SG_ID" ] && [ "$NODE_SG_ID" != "None" ]; then
-            aws ec2 revoke-security-group-ingress \
-              --group-id "${{ vars.RDS_SG_ID }}" \
-              --protocol tcp \
-              --port 5432 \
-              --source-group "$NODE_SG_ID" || true
-          fi
-
-      - name: Destroy PR environment via service_builder
-        run: |
-          docker run --rm \
-            -e EP_ACTION=destroy \
-            -e EP_ENV="pr-${PR_NUM}" \
-            -e EP_SERVICE_NAME="water_data_tool_pr_${PR_NUM}" \
-            -e EP_SERVICE_SHORT_NAME="pr${PR_NUM}" \
-            -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
-            -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
-            -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
-            -e EP_SERVICE_INSTANCE_COUNT="1" \
-            -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
-            -e EP_SERVICE_DOMAIN="water-data-tool-pr-${PR_NUM}.policyinnovation.info" \
-            -e EP_SERVICE_PORT="3000" \
-            -e EP_SERVICE_HEALTH_PORT="3000" \
-            -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
-            -e EP_CREATE_ECR_REPO="false" \
-            -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-            -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-            -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
-            -e AWS_REGION="$AWS_REGION" \
-            "$SERVICE_BUILDER_IMAGE"
+      - name: Tear down PR environment
+        uses: ./.github/actions/teardown-pr
+        with:
+          pr_number: ${{ env.PR_NUM }}
+          rds_sg_id: ${{ vars.RDS_SG_ID }}
 
       - name: Close PR and comment
         env:


### PR DESCRIPTION
## Summary

The **RDS revocation** and **ECS destroy** steps were duplicated across `deploy-client-aws.yml` and `teardown-pr-env.yml`. This extracts them into a single composite action at `.github/actions/teardown-pr/action.yml` which both workflows now call.
  
Also updates the date format in `list-pr-environments.yml` to Eastern time in a human-readable format.

### Changed files:
- **.github/actions/teardown-pr/action.yml** — new composite action (source of truth for teardown
   logic)
- **.github/workflows/deploy-client-aws.yml** — calls composite action in pr-teardown job
- **.github/workflows/teardown-pr-env.yml** — calls composite action
- **.github/workflows/list-pr-environments.yml** — date format tweak