### PR TITLE
Fix/address histogram feedback round 2

### DIFF
--- a/app/javascript/controllers/slider_controller.js
+++ b/app/javascript/controllers/slider_controller.js
@@ -127,7 +127,7 @@ export default class extends Controller {
     } else {
       // count and currency: floor at 1 so scale always starts at 1 / $1
       domain_min = Math.min(domain_min, 1)
-      // Extend to the next nice round boundary so the axis always ends on a clean number.
+      // Extend past data max so bars end with visual breathing room before the track edge.
       domain_max = this.#niceMax(domain_min, domain_max)
     }
 
@@ -193,20 +193,21 @@ export default class extends Controller {
     const maxCount = Math.max(...this.#bins.map(b => b.count))
     const sqrtMax = maxCount ? Math.sqrt(maxCount) : 1
     const barArea = SVG_H - HANDLE_R * 2 - 2 - BAR_TOP_PAD
-    const trackW = this.#svgW - PAD_L - PAD_R
-    const barW = trackW / this.#bins.length
     const gap = 1
-    const drawW = Math.max(1, barW - gap)
 
     // Square root scale: water data is right-skewed — most systems cluster at low values with a
     // long sparse tail. Sqrt lifts small bars enough to show the distribution shape without
     // flattening them like linear would. Gentler than log, and safe for zero-count bins.
     const hitRects = []
-    this.#bins.forEach((bin, i) => {
+    this.#bins.forEach((bin) => {
       const h = bin.count > 0 && maxCount ? Math.max(1, (Math.sqrt(bin.count) / sqrtMax) * barArea) : 0
-      const bx = PAD_L + i * barW + gap / 2
+      // Value-based positioning: use the bin's theoretical boundaries via #valToX so bars
+      // stay aligned with handle positions regardless of domain extension (e.g. niceMax).
+      const binLeft  = this.#valToX(bin.min)
+      const binRight = this.#valToX(bin.max)
+      const bx = binLeft + gap / 2
+      const bw = Math.max(1, binRight - binLeft - gap)
       const by = SVG_H - HANDLE_R * 2 - h - 1
-      const bw = drawW
       const r  = h > 0 ? Math.min(3, h / 2, bw / 2) : 0
       const d  = h > 0
         ? `M ${bx} ${by + h} L ${bx} ${by + r} Q ${bx} ${by} ${bx + r} ${by} L ${bx + bw - r} ${by} Q ${bx + bw} ${by} ${bx + bw} ${by + r} L ${bx + bw} ${by + h} Z`
@@ -216,7 +217,7 @@ export default class extends Controller {
       this.#bars.push(bar)
 
       if (bin.count > 0) {
-        const cx = PAD_L + i * barW + barW / 2
+        const cx = (binLeft + binRight) / 2
         const label = bin.count === 1 ? "1 utility" : `${bin.count.toLocaleString("en-US")} utilities`
         const baseline = SVG_H - HANDLE_R * 2 - 1
         const hitH = Math.max(12, h)
@@ -333,7 +334,10 @@ export default class extends Controller {
   #niceMax(min, max) {
     if (max <= min) return max
     const step = this.#niceStep(max - min)
-    return Math.ceil(max / step) * step
+    const candidate = Math.ceil(max / step) * step
+    // Must be strictly > max so the last bin (theoretical max = domain_max + 1)
+    // always lands within the track when using value-based bar positioning.
+    return candidate > max ? candidate : candidate + step
   }
 
   #makeTip(style = "light") {

--- a/app/javascript/controllers/slider_controller.js
+++ b/app/javascript/controllers/slider_controller.js
@@ -2,20 +2,18 @@ import { Controller } from "@hotwired/stimulus"
 
 // Histogram data is global (not per-user or per-filter scope), so keying on field is stable.
 const CACHE = new Map()
-const SVG_W = 200
-const SVG_H = 80        // bar + handle area
-const X_AXIS_H = 10     // tick lines below the handle baseline
-const BAR_TOP_PAD = 6   // clear pixels above tallest bar so y-axis label fits
-const HOVER_AREA_H = 26 // extra viewBox headroom above y=0 so hover pill clears the tallest bar
+const SVG_H = 100       // bar + handle area
+const X_AXIS_H = 12     // tick lines below the handle baseline
+const BAR_TOP_PAD = 4   // clear pixels above tallest bar so y-axis label fits
+const HOVER_AREA_H = 16 // extra viewBox headroom above y=0 so hover pill clears the tallest bar
 const HANDLE_R = 5
 const Y_AXIS_W = 26     // pixels reserved on the left for y-axis label and tick marks
 const PAD_L = Y_AXIS_W + HANDLE_R  // left track inset (y-axis area + handle clearance)
 const PAD_R = HANDLE_R             // right track inset (handle clearance only)
 const HANDLE_Y = SVG_H - HANDLE_R * 2  // handle center on the histogram baseline
-const BLUE = "#3B82F6"
-const GRAY = "#bfbfbf"
-const DARK = "#4b5563"       // neutral-600 — visually consistent as both stroke and filled circle
-const LIGHT_GRAY = "#9ca3af" // neutral-400 — lighter tone for y-axis labels
+const BLUE         = "#3B82F6" // blue-500 — highlighted bars, active handles
+const NEUTRAL_400  = "#bfbfbf" // --color-neutral-400 in @theme — unselected bars
+const NEUTRAL_700  = "#565656" // --color-neutral-700 in @theme — axes, tick marks, labels, inactive handles
 const NS = "http://www.w3.org/2000/svg"
 
 export default class extends Controller {
@@ -37,7 +35,7 @@ export default class extends Controller {
   #maxHandle = null
   #bars = []
   #rect = null
-  #svgW = SVG_W
+  #svgW = 0
   #ro = null
   #needsDefaults = false
   #minSet = false
@@ -204,10 +202,10 @@ export default class extends Controller {
       // Value-based positioning: use the bin's theoretical boundaries via #valToX so bars
       // stay aligned with handle positions regardless of domain extension (e.g. niceMax).
       const binLeft  = this.#valToX(bin.min)
-      const binRight = this.#valToX(bin.max)
+      const binRight = Math.min(this.#valToX(bin.max), this.#svgW - PAD_R)
       const bx = binLeft + gap / 2
       const bw = Math.max(1, binRight - binLeft - gap)
-      const by = SVG_H - HANDLE_R * 2 - h - 1
+      const by = HANDLE_Y - h
       const r  = h > 0 ? Math.min(3, h / 2, bw / 2) : 0
       const d  = h > 0
         ? `M ${bx} ${by + h} L ${bx} ${by + r} Q ${bx} ${by} ${bx + r} ${by} L ${bx + bw - r} ${by} Q ${bx + bw} ${by} ${bx + bw} ${by + r} L ${bx + bw} ${by + h} Z`
@@ -219,7 +217,7 @@ export default class extends Controller {
       if (bin.count > 0) {
         const cx = (binLeft + binRight) / 2
         const label = bin.count === 1 ? "1 utility" : `${bin.count.toLocaleString("en-US")} utilities`
-        const baseline = SVG_H - HANDLE_R * 2 - 1
+        const baseline = HANDLE_Y
         const hitH = Math.max(12, h)
         const hit = this.#el("rect", {
           x: bx, y: baseline - hitH, width: bw, height: hitH,
@@ -257,22 +255,22 @@ export default class extends Controller {
 
   #drawXAxis(svg) {
     // Baseline sits flush at bar bottom; tick marks sit below the handles.
-    const baseY = SVG_H - HANDLE_R * 2 - 1
+    const baseY = HANDLE_Y
     svg.appendChild(this.#el("line", {
       x1: PAD_L, x2: this.#svgW - PAD_R,
       y1: baseY, y2: baseY,
-      stroke: DARK, "stroke-width": 0.5
+      stroke: NEUTRAL_700, "stroke-width": 1, "shape-rendering": "crispEdges"
     }))
 
     const ticks = this.#xTicks()
     const tickTop = baseY
-    const tickBot = tickTop + 4
+    const tickBot = tickTop + 6
 
     ticks.forEach(({ value }) => {
       svg.appendChild(this.#el("line", {
         x1: this.#valToX(value), x2: this.#valToX(value),
         y1: tickTop, y2: tickBot,
-        stroke: DARK, "stroke-width": 1
+        stroke: NEUTRAL_700, "stroke-width": 1.5
       }))
     })
   }
@@ -350,7 +348,7 @@ export default class extends Controller {
       "stroke-width": 1
     })
     const text = this.#el("text", {
-      "text-anchor": "middle", "font-size": 12,
+      "text-anchor": "middle", "font-size": 14,
       fill: isDark ? "white" : "#4b5563",
       "dominant-baseline": "middle"
     })
@@ -432,7 +430,7 @@ export default class extends Controller {
     const g = which === "min" ? this.#minHandle : this.#maxHandle
     if (!g) return
     g.innerHTML = ""
-    g.appendChild(this.#el("circle", { cx: 0, cy: 0, r: HANDLE_R, fill: DARK }))
+    g.appendChild(this.#el("circle", { cx: 0, cy: 0, r: HANDLE_R, fill: NEUTRAL_700 }))
   }
 
   #setHandleActive(which) {
@@ -458,7 +456,7 @@ export default class extends Controller {
   #colorBars() {
     this.#bars.forEach(bar => {
       const inside = +bar.dataset.binMax > this.#curMin && +bar.dataset.binMin <= this.#curMax
-      bar.setAttribute("fill", inside ? BLUE : GRAY)
+      bar.setAttribute("fill", inside ? BLUE : NEUTRAL_400)
     })
   }
 
@@ -537,11 +535,9 @@ export default class extends Controller {
     if (textChanged || this.#tipTextW[which] === 0) this.#tipTextW[which] = text.getComputedTextLength()
     const textW = this.#tipTextW[which]
     // Minimum width ensures the bottom always has a straight segment for the arrow.
-    const pillW    = Math.max(textW + padX * 2, 2 * (rx + arrowHW) + 2)
-    const pillX    = Math.max(PAD_L - rx - arrowHW, Math.min(this.#svgW - PAD_R - pillW, x - pillW / 2))
-    const arrowXMin = pillX + rx + arrowHW
-    const arrowXMax = pillX + pillW - rx - arrowHW
-    const arrowX    = Math.max(arrowXMin, Math.min(arrowXMax, x))
+    const pillW  = Math.max(textW + padX * 2, 2 * (rx + arrowHW) + 2)
+    const pillX  = x - pillW / 2
+    const arrowX = x
 
     // Single path: capsule (oval ends via arcs) + downward-pointing arrow, drawn clockwise.
     const d = [
@@ -568,12 +564,12 @@ export default class extends Controller {
   #drawYAxis(svg, maxCount, sqrtMax, barArea) {
     // Entire y-axis is decorative — wrapped in aria-hidden so AT uses the handle ARIA instead.
     const g = this.#el("g", { "aria-hidden": "true" })
-    const baseY = SVG_H - HANDLE_R * 2 - 1
+    const baseY = HANDLE_Y
     const midY = baseY / 2
 
     const axisLabel = this.#el("text", {
       "text-anchor": "middle", "dominant-baseline": "middle",
-      "font-size": 10, fill: LIGHT_GRAY,
+      "font-size": 14, fill: NEUTRAL_700,
       transform: `translate(6, ${midY}) rotate(-90)`
     })
     axisLabel.textContent = "# of utilities"
@@ -585,9 +581,9 @@ export default class extends Controller {
       this.#yTicks(maxCount).forEach(count => {
         const tickY = count === 0 ? baseY : baseY - (Math.sqrt(count) / sqrtMax) * barArea
         g.appendChild(this.#el("line", {
-          x1: tickCX - 2, x2: tickCX + 2,
+          x1: tickCX - 3, x2: tickCX + 3,
           y1: tickY, y2: tickY,
-          stroke: LIGHT_GRAY, "stroke-width": 0.5
+          stroke: NEUTRAL_700, "stroke-width": 1
         }))
       })
     }

--- a/app/models/concerns/histogrammable.rb
+++ b/app/models/concerns/histogrammable.rb
@@ -46,7 +46,7 @@ module Histogrammable
         else
           30
         end
-        upper_bound = (format == "count") ? domain_min + num_bins : domain_max + 1
+        upper_bound = domain_max + 1
       end
 
       bin_width = (upper_bound.to_f - domain_min) / num_bins

--- a/app/views/home/_filter_menus.html.erb
+++ b/app/views/home/_filter_menus.html.erb
@@ -114,9 +114,9 @@
                   aria-controls="subcat-health-5yr">
             <%= icon("arrow-down", classes: "h-3 w-3 transition-transform duration-150") %>
           </button>
-          <div id="subcat-health-5yr" class="hidden pl-4 pb-1" data-subcat-panel
+          <div id="subcat-health-5yr" class="hidden pl-2 pb-1" data-subcat-panel
                data-action="change->filter#syncParentFromSubcat">
-          <ul class="space-y-1 mt-1 list-none px-1">
+          <ul class="mt-1 list-none px-1">
             <%= render Filters::GroupRangeComponent.new(
                   checkbox_id: "viols-groundwater-5yr", panel_id: "slider-groundwater-5yr",
                   label: "Ground water rule", tooltip_text: filter_tooltips["groundwater_rule"],
@@ -172,9 +172,9 @@
                   aria-controls="subcat-health-10yr">
             <%= icon("arrow-down", classes: "h-3 w-3 transition-transform duration-150") %>
           </button>
-          <div id="subcat-health-10yr" class="hidden pl-4 pb-1" data-subcat-panel
+          <div id="subcat-health-10yr" class="hidden pl-2 pb-1" data-subcat-panel
                data-action="change->filter#syncParentFromSubcat">
-          <ul class="space-y-1 mt-1 list-none px-1">
+          <ul class="mt-1 list-none px-1">
             <%= render Filters::GroupRangeComponent.new(
                   checkbox_id: "viols-groundwater-10yr", panel_id: "slider-groundwater-10yr",
                   label: "Ground water rule", tooltip_text: filter_tooltips["groundwater_rule"],
@@ -230,7 +230,7 @@
                   aria-controls="subcat-paperwork-5yr">
             <%= icon("arrow-down", classes: "h-3 w-3 transition-transform duration-150") %>
           </button>
-          <div id="subcat-paperwork-5yr" class="hidden px-4 py-2" data-subcat-panel
+          <div id="subcat-paperwork-5yr" class="hidden px-2 py-2" data-subcat-panel
                data-controller="slider"
                data-slider-field-value="paperwork_violations_5yr"
                data-slider-url-value="<%= histogram_path %>">
@@ -256,7 +256,7 @@
                   aria-controls="subcat-paperwork-10yr">
             <%= icon("arrow-down", classes: "h-3 w-3 transition-transform duration-150") %>
           </button>
-          <div id="subcat-paperwork-10yr" class="hidden px-4 py-2" data-subcat-panel
+          <div id="subcat-paperwork-10yr" class="hidden px-2 py-2" data-subcat-panel
                data-controller="slider"
                data-slider-field-value="paperwork_violations_10yr"
                data-slider-url-value="<%= histogram_path %>">
@@ -314,7 +314,7 @@
                   aria-expanded="false" aria-controls="subcat-rate-tier">
             <%= icon("arrow-down", classes: "h-3 w-3 transition-transform duration-150") %>
           </button>
-          <div id="subcat-rate-tier" class="hidden pl-4 pb-2" data-subcat-panel>
+          <div id="subcat-rate-tier" class="hidden pl-2 pb-2" data-subcat-panel>
             <ul class="space-y-0.5 mt-1 list-none px-1">
               <li class="<%= filter_row_classes %>"><input type="checkbox" class="toggle default-checked" checked id="rate-tier-lt125">
                   <label for="rate-tier-lt125">Under $125</label></li>
@@ -374,9 +374,9 @@
                   aria-expanded="false" aria-controls="subcat-watershed-hazards">
             <%= icon("arrow-down", classes: "h-3 w-3 transition-transform duration-150") %>
           </button>
-          <div id="subcat-watershed-hazards" class="hidden pl-4 pb-1" data-subcat-panel
+          <div id="subcat-watershed-hazards" class="hidden pl-2 pb-1" data-subcat-panel
                data-action="change->filter#syncParentFromSubcat">
-            <ul class="space-y-1 mt-1 list-none px-1">
+            <ul class="mt-1 list-none px-1">
               <%= render Filters::GroupRangeComponent.new(
                     checkbox_id: "more-num-facilities", panel_id: "slider-num-facilities",
                     label: "Source water connections", tooltip_text: filter_tooltips["source_water_connections"],

--- a/app/views/home/_slider_panel.html.erb
+++ b/app/views/home/_slider_panel.html.erb
@@ -1,13 +1,14 @@
 <% slider_format = local_assigns.fetch(:format, nil) %>
-<div id="<%= panel_id %>" class="hidden px-2 pt-2 pb-1" data-controller="slider" data-slider-field-value="<%= field %>" data-slider-url-value="<%= histogram_path %>"<% if slider_format %> data-slider-format-value="<%= slider_format %>"<% end %>>
-  <p class="text-xs font-bold text-neutral-600 mb-2"><%= local_assigns.fetch(:label, "Number of violations") %></p>
-  <svg data-slider-target="chart" class="w-full overflow-visible" height="90"></svg>
-  <div id="<%= panel_id %>-range-axis" aria-hidden="true" class="flex justify-between text-xs mt-1 text-neutral-600">
+<div id="<%= panel_id %>" class="hidden py-2" data-controller="slider" data-slider-field-value="<%= field %>" data-slider-url-value="<%= histogram_path %>"<% if slider_format %> data-slider-format-value="<%= slider_format %>"<% end %>>
+  <p class="text-sm font-bold text-neutral-700"><%= local_assigns.fetch(:label, "Number of violations") %></p>
+  <svg data-slider-target="chart" class="w-full overflow-visible" height="128"></svg>
+  <%# pl-[31px] = PAD_L (Y_AXIS_W + HANDLE_R), pr-[5px] = PAD_R (HANDLE_R) — must match slider_controller.js %>
+  <div id="<%= panel_id %>-range-axis" aria-hidden="true" class="flex justify-between text-sm text-neutral-700 pl-[31px] pr-[5px]">
     <span data-slider-target="minLabel"></span>
     <span data-slider-target="maxLabel"></span>
   </div>
   <span class="sr-only" data-slider-target="zeroLabel"></span>
-  <div class="flex items-center gap-1 mt-2 text-xs text-neutral-600">
+  <div class="flex items-center gap-1 mt-2 text-sm text-neutral-700 pl-[31px] pr-[5px]"> <%# pl/pr match PAD_L/PAD_R above %>
     <div class="flex flex-col flex-1 min-w-0">
       <input type="text"
              id="<%= panel_id %>-min-text"
@@ -17,7 +18,7 @@
              inputmode="numeric"
              autocomplete="off"
              aria-label="Minimum filter value"
-             class="w-full text-xs font-bold bg-neutral-50 border border-neutral-300 rounded px-1.5 py-1 text-neutral-700">
+             class="w-full text-sm font-bold bg-neutral-50 border border-neutral-300 rounded px-1.5 py-1 text-neutral-700">
     </div>
     <span aria-hidden="true">-</span>
     <div class="flex flex-col flex-1 min-w-0">
@@ -29,7 +30,7 @@
              inputmode="numeric"
              autocomplete="off"
              aria-label="Maximum filter value"
-             class="w-full text-xs font-bold bg-neutral-50 border border-neutral-300 rounded px-1.5 py-1 text-neutral-700 text-right">
+             class="w-full text-sm font-bold bg-neutral-50 border border-neutral-300 rounded px-1.5 py-1 text-neutral-700 text-right">
     </div>
   </div>
   <input type="hidden" data-slider-target="minInput" id="<%= min_input_id %>">

--- a/docs/frontend_refactor/HISTORGRAMS.md
+++ b/docs/frontend_refactor/HISTORGRAMS.md
@@ -90,14 +90,14 @@ Equal-width, 30 bins. The `min_threshold: 0` already excludes zero-valued rows f
 
 ## Bar Positioning
 
-Bars are positioned by **array index** — `x = PAD_L + i * barW` — which is equivalent to value-axis positioning because the backend always returns exactly `numBins` entries with uniform theoretical boundaries. The two approaches give identical results; index-based is simpler and is what the code uses.
+Bars are positioned by **value** — each bar's left and right pixel edges are computed via `#valToX(bin.min)` and `#valToX(bin.max)`. This ensures bars and handles share the same coordinate system regardless of any frontend domain extension (e.g. `niceMax`). An earlier index-based approach (`x = PAD_L + i * barW`) was equivalent only when `domMax` exactly matched the backend's bin upper boundary; value-based positioning removes that hidden dependency.
 
-The track is inset asymmetrically: `PAD_L` on the left (reserves space for the y-axis label and tick marks) and `PAD_R` on the right (handle clearance only). Bar width is `trackW / numBins` where `trackW = svgW - PAD_L - PAD_R`.
+The track is inset asymmetrically: `PAD_L` on the left (reserves space for the y-axis label and tick marks) and `PAD_R` on the right (handle clearance only).
 
 Empty bins (`count: 0`) render as zero-height paths — genuine visual gaps in the distribution.
 
 ### Handle-to-bar alignment
-The min handle at `domMin` sits at the left edge of the first bar. The max handle at `domMax` sits at the right edge of the last bar. Handles at intermediate values land somewhere within the bar that contains that value (not necessarily centered — this is expected and correct). The floating tooltip above the handle shows the precise value; bar coloring is approximate visual context.
+The min handle at `domMin` sits at the left edge of the first bar. The max handle at `domMax` (the `niceMax`-extended boundary) sits at the right edge of the track, leaving a small visual gap between the last bar and the track edge for readability. Handles at intermediate values land somewhere within the bar that contains that value (not necessarily centered — this is expected and correct). The floating tooltip above the handle shows the precise value; bar coloring is approximate visual context.
 
 ### Bar coloring
 A bar is colored blue (inside the selected range) or gray (outside) using its theoretical boundaries:

--- a/spec/models/concerns/histogrammable_spec.rb
+++ b/spec/models/concerns/histogrammable_spec.rb
@@ -206,6 +206,19 @@ RSpec.describe Histogrammable, type: :model do
         result = ViolationsSummary.histogram_bins(:paperwork_violations_5yr, format: "count")
         expect(result[:bins].length).to eq(30)
       end
+
+      it "spans the full data domain when integer range is capped at 30 bins" do
+        pws_i = create(:public_water_system)
+        pws_i2 = create(:public_water_system)
+        create(:violations_summary, public_water_system: pws_i, pwsid: pws_i.pwsid,
+          paperwork_violations_5yr: 1)
+        create(:violations_summary, public_water_system: pws_i2, pwsid: pws_i2.pwsid,
+          paperwork_violations_5yr: 50)
+
+        result = ViolationsSummary.histogram_bins(:paperwork_violations_5yr, format: "count")
+        expect(result[:bins].first[:min]).to be_within(0.0001).of(1)
+        expect(result[:bins].last[:max]).to be_within(0.0001).of(51)
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

This PR addresses some feedback _(noted on #106 )_ related to the recent Histogram work, specifically:

- Highlighted bar/scroller circle mismatch bug is gone.
- Chart is slightly taller and slightly wider, with some whitespaces removed/condensed
- All font sizes in the chart area (labels, numbers, etc.) are now size 14
- The Font color is darker

### Screenshots
- located in last comment of #106 ticket.
