### PR TITLE
[Fix] Reconfigure GeoJSON Export for Speed + Accuracy

### DIFF
--- a/app/controllers/public_water_systems/exports_controller.rb
+++ b/app/controllers/public_water_systems/exports_controller.rb
@@ -1,16 +1,12 @@
 module PublicWaterSystems
   class ExportsController < ApplicationController
     def show
-      scope = PublicWaterSystem
-        .apply_filters(params)
-        .with_details
-
-      exporter = PublicWaterSystemExporter.new(scope)
+      base_scope = PublicWaterSystem.apply_filters(params)
 
       if params[:file_format] == "geojson"
-        render_geojson_export(exporter)
+        render_geojson_export(PublicWaterSystemExporter.new(base_scope))
       else
-        render_csv_export(exporter)
+        render_csv_export(PublicWaterSystemExporter.new(base_scope.with_details))
       end
     end
 
@@ -23,14 +19,10 @@ module PublicWaterSystems
     end
 
     def render_geojson_export(exporter)
-      compressed = ActiveSupport::Gzip.compress(exporter.to_geojson.to_json)
-
-      # Content-Encoding: gzip tells the browser to decompress before saving.
-      # Rack::Deflater is NOT in the middleware stack, so there is no double-compression risk.
-      response.headers["Content-Encoding"] = "gzip"
-      send_data compressed,
-        type: "application/json",
-        disposition: 'attachment; filename="export.geojson"'
+      response.content_type = "application/json; charset=utf-8"
+      response.headers["Content-Disposition"] = 'attachment; filename="export.geojson"'
+      # Content-Length is intentionally absent — the streamed response size is unknown in advance.
+      self.response_body = exporter.to_geojson_stream
     end
   end
 end

--- a/app/exporters/public_water_system_exporter.rb
+++ b/app/exporters/public_water_system_exporter.rb
@@ -1,6 +1,45 @@
 require "csv"
 
 class PublicWaterSystemExporter
+  BATCH_SIZE = 500
+
+  # Exported GeoJSON property columns, grouped by SQL table alias.
+  # Each [alias, columns] pair expands to alias.col => alias.col entries.
+  # The one renamed property (total_bwn → bws.total_notices) is merged at the end.
+  GEOJSON_PROPERTY_COLUMNS = [
+    ["pws", %w[
+      pwsid pws_name detailed_facility_report stusps counties gw_sw_code
+      source_water_protection_code owner_type primacy_type is_wholesaler
+      is_school_or_daycare service_area_type area_sq_miles open_health_viol
+    ]],
+    ["vs", %w[
+      health_violations_5yr groundwater_rule_5yr surface_water_treatment_5yr
+      lead_and_copper_5yr radionuclides_5yr inorganic_chemicals_5yr
+      synthetic_organic_chemicals_5yr volatile_organic_chemicals_5yr
+      total_coliform_5yr stage_1_disinfectants_5yr stage_2_disinfectants_5yr
+      health_violations_10yr groundwater_rule_10yr surface_water_treatment_10yr
+      lead_and_copper_10yr radionuclides_10yr inorganic_chemicals_10yr
+      synthetic_organic_chemicals_10yr volatile_organic_chemicals_10yr
+      total_coliform_10yr stage_1_disinfectants_10yr stage_2_disinfectants_10yr
+      paperwork_violations_5yr paperwork_violations_10yr
+    ]],
+    ["d", %w[
+      total_population population_density poverty_rate unemployment_rate
+      median_household_income bachelors_degree_rate age_under_5_rate age_over_61_rate
+      poc_rate white_rate black_rate aian_rate napi_rate asian_rate hispanic_rate
+      other_race_rate mixed_race_rate most_common_rate_tier
+    ]],
+    ["td", %w[population_pct_change mhi_pct_change]],
+    ["ej", %w[cejst_disadvantaged_pct svi_overall_pctl cvi_overall_score]],
+    ["fs", %w[times_funded total_srf_assistance total_principal_forgiveness]],
+    ["wh", %w[
+      num_facilities permit_effluent_violations open_underground_storage_tanks
+      risk_management_plan_facilities impaired_streams_303d
+    ]]
+  ].each_with_object({}) { |(tbl, cols), h|
+    cols.each { |col| h[col] = "#{tbl}.#{col}" }
+  }.merge("total_bwn" => "bws.total_notices").freeze
+
   # Human-readable headers matching the legacy datatable_export.csv output.
   # Order matters — must stay in sync with #csv_row below.
   CSV_HEADERS = [
@@ -63,14 +102,30 @@ class PublicWaterSystemExporter
     end
   end
 
-  def to_geojson
-    features = @scope.map do |pws|
-      geometry = if (geom = pws.service_area_geometry&.geom)
-        RGeo::GeoJSON.encode(geom)
+  # Returns an Enumerator that streams a GeoJSON FeatureCollection as JSON
+  # chunks. All serialisation (geometry encoding, property building) runs in
+  # PostgreSQL via ST_AsGeoJSON + json_build_object; records are fetched in
+  # cursor-based batches to keep memory usage flat regardless of result size.
+  def to_geojson_stream
+    Enumerator.new do |y|
+      y << '{"type":"FeatureCollection","features":['
+      first = true
+      # Empty string is a valid sentinel: all EPA pwsids are non-empty, so
+      # WHERE pws.pwsid > '' matches every row on the first iteration.
+      last_pwsid = ""
+      loop do
+        rows = fetch_feature_batch(last_pwsid)
+        break if rows.ntuples.zero?
+        rows.each do |row|
+          y << "," unless first
+          first = false
+          y << row["feature"]
+          last_pwsid = row["pwsid"]
+        end
+        break if rows.ntuples < BATCH_SIZE
       end
-      {type: "Feature", geometry: geometry, properties: geojson_properties(pws)}
+      y << "]}"
     end
-    {type: "FeatureCollection", features: features}
   end
 
   private
@@ -115,82 +170,55 @@ class PublicWaterSystemExporter
     ]
   end
 
-  # Returns a flat hash of properties for GeoJSON features (snake_case keys,
-  # matching the legacy download_geojson.php output).
-  def geojson_properties(pws)
-    vs = pws.violations_summary
-    bws = pws.boil_water_summary
-    d = pws.demographic
-    td = pws.trend_datum
-    ej = pws.environmental_justice
-    fs = pws.funding_summary
-    wh = pws.watershed_hazard
+  def properties_sql
+    # PostgreSQL's json_build_object caps at 100 arguments (50 key-value pairs).
+    # Slice at 49 pairs to stay safely under that limit; merge chunks via the
+    # JSONB || operator then cast back to json.
+    # All keys and column references come from frozen constants — never extend
+    # this with runtime/user-supplied values.
+    @properties_sql ||= begin
+      conn = ApplicationRecord.connection
+      chunks = GEOJSON_PROPERTY_COLUMNS.each_slice(49).map do |slice|
+        pairs = slice.flat_map do |k, v|
+          table, col = v.split(".")
+          [conn.quote(k), "#{conn.quote_column_name(table)}.#{conn.quote_column_name(col)}"]
+        end
+        "jsonb_build_object(#{pairs.join(", ")})"
+      end
+      "(#{chunks.join(" || ")})::json"
+    end
+  end
 
-    {
-      pws_name: pws.pws_name, pwsid: pws.pwsid,
-      detailed_facility_report: pws.detailed_facility_report,
-      stusps: pws.stusps, counties: pws.counties,
-      gw_sw_code: pws.gw_sw_code, source_water_protection_code: pws.source_water_protection_code,
-      owner_type: pws.owner_type, primacy_type: pws.primacy_type,
-      is_wholesaler: pws.is_wholesaler, is_school_or_daycare: pws.is_school_or_daycare,
-      service_area_type: pws.service_area_type, area_sq_miles: pws.area_sq_miles,
-      open_health_viol: pws.open_health_viol,
-      health_violations_5yr: vs&.health_violations_5yr,
-      groundwater_rule_5yr: vs&.groundwater_rule_5yr,
-      surface_water_treatment_5yr: vs&.surface_water_treatment_5yr,
-      lead_and_copper_5yr: vs&.lead_and_copper_5yr,
-      radionuclides_5yr: vs&.radionuclides_5yr,
-      inorganic_chemicals_5yr: vs&.inorganic_chemicals_5yr,
-      synthetic_organic_chemicals_5yr: vs&.synthetic_organic_chemicals_5yr,
-      volatile_organic_chemicals_5yr: vs&.volatile_organic_chemicals_5yr,
-      total_coliform_5yr: vs&.total_coliform_5yr,
-      stage_1_disinfectants_5yr: vs&.stage_1_disinfectants_5yr,
-      stage_2_disinfectants_5yr: vs&.stage_2_disinfectants_5yr,
-      health_violations_10yr: vs&.health_violations_10yr,
-      groundwater_rule_10yr: vs&.groundwater_rule_10yr,
-      surface_water_treatment_10yr: vs&.surface_water_treatment_10yr,
-      lead_and_copper_10yr: vs&.lead_and_copper_10yr,
-      radionuclides_10yr: vs&.radionuclides_10yr,
-      inorganic_chemicals_10yr: vs&.inorganic_chemicals_10yr,
-      synthetic_organic_chemicals_10yr: vs&.synthetic_organic_chemicals_10yr,
-      volatile_organic_chemicals_10yr: vs&.volatile_organic_chemicals_10yr,
-      total_coliform_10yr: vs&.total_coliform_10yr,
-      stage_1_disinfectants_10yr: vs&.stage_1_disinfectants_10yr,
-      stage_2_disinfectants_10yr: vs&.stage_2_disinfectants_10yr,
-      paperwork_violations_5yr: vs&.paperwork_violations_5yr,
-      paperwork_violations_10yr: vs&.paperwork_violations_10yr,
-      total_bwn: bws&.total_notices,
-      total_population: d&.total_population,
-      population_density: d&.population_density,
-      population_pct_change: td&.population_pct_change,
-      mhi_pct_change: td&.mhi_pct_change,
-      poverty_rate: d&.poverty_rate,
-      unemployment_rate: d&.unemployment_rate,
-      median_household_income: d&.median_household_income,
-      bachelors_degree_rate: d&.bachelors_degree_rate,
-      age_under_5_rate: d&.age_under_5_rate,
-      age_over_61_rate: d&.age_over_61_rate,
-      poc_rate: d&.poc_rate,
-      white_rate: d&.white_rate,
-      black_rate: d&.black_rate,
-      aian_rate: d&.aian_rate,
-      napi_rate: d&.napi_rate,
-      asian_rate: d&.asian_rate,
-      hispanic_rate: d&.hispanic_rate,
-      other_race_rate: d&.other_race_rate,
-      mixed_race_rate: d&.mixed_race_rate,
-      cejst_disadvantaged_pct: ej&.cejst_disadvantaged_pct,
-      svi_overall_pctl: ej&.svi_overall_pctl,
-      cvi_overall_score: ej&.cvi_overall_score,
-      most_common_rate_tier: d&.most_common_rate_tier,
-      times_funded: fs&.times_funded,
-      total_srf_assistance: fs&.total_srf_assistance,
-      total_principal_forgiveness: fs&.total_principal_forgiveness,
-      num_facilities: wh&.num_facilities,
-      permit_effluent_violations: wh&.permit_effluent_violations,
-      open_underground_storage_tanks: wh&.open_underground_storage_tanks,
-      risk_management_plan_facilities: wh&.risk_management_plan_facilities,
-      impaired_streams_303d: wh&.impaired_streams_303d
-    }
+  def filtered_ids_sql
+    @filtered_ids_sql ||= @scope.unscope(:order).select("public_water_systems.pwsid").distinct.to_sql
+  end
+
+  # SAFETY: all interpolated SQL fragments (properties_sql, filtered_ids_sql,
+  # BATCH_SIZE) are derived from frozen constants or sanitised inputs.
+  # Never pass user-supplied data into this method.
+  def fetch_feature_batch(last_pwsid)
+    quoted = ApplicationRecord.connection.quote(last_pwsid)
+    ApplicationRecord.connection.execute(<<~SQL)
+      SELECT
+        pws.pwsid,
+        json_build_object(
+          'type', 'Feature',
+          'geometry', ST_AsGeoJSON(sag.geom)::json,
+          'properties', #{properties_sql}
+        )::text AS feature
+      FROM public_water_systems pws
+      INNER JOIN (#{filtered_ids_sql}) filtered ON filtered.pwsid = pws.pwsid
+      LEFT JOIN service_area_geometries sag ON sag.pwsid = pws.pwsid
+      LEFT JOIN violations_summaries   vs  ON vs.pwsid  = pws.pwsid
+      LEFT JOIN boil_water_summaries   bws ON bws.pwsid = pws.pwsid
+      LEFT JOIN demographics           d   ON d.pwsid   = pws.pwsid
+      LEFT JOIN trend_data             td  ON td.pwsid  = pws.pwsid
+      LEFT JOIN environmental_justices ej  ON ej.pwsid  = pws.pwsid
+      LEFT JOIN funding_summaries      fs  ON fs.pwsid  = pws.pwsid
+      LEFT JOIN watershed_hazards      wh  ON wh.pwsid  = pws.pwsid
+      WHERE pws.pwsid > #{quoted}
+      ORDER BY pws.pwsid
+      LIMIT #{BATCH_SIZE}
+    SQL
   end
 end

--- a/app/exporters/public_water_system_exporter.rb
+++ b/app/exporters/public_water_system_exporter.rb
@@ -107,8 +107,8 @@ class PublicWaterSystemExporter
   # PostgreSQL via ST_AsGeoJSON + json_build_object; records are fetched in
   # cursor-based batches to keep memory usage flat regardless of result size.
   def to_geojson_stream
-    Enumerator.new do |y|
-      y << '{"type":"FeatureCollection","features":['
+    Enumerator.new do |stream|
+      stream << '{"type":"FeatureCollection","features":['
       first = true
       # Empty string is a valid sentinel: all EPA pwsids are non-empty, so
       # WHERE pws.pwsid > '' matches every row on the first iteration.
@@ -117,14 +117,14 @@ class PublicWaterSystemExporter
         rows = fetch_feature_batch(last_pwsid)
         break if rows.ntuples.zero?
         rows.each do |row|
-          y << "," unless first
+          stream << "," unless first
           first = false
-          y << row["feature"]
+          stream << row["feature"]
           last_pwsid = row["pwsid"]
         end
         break if rows.ntuples < BATCH_SIZE
       end
-      y << "]}"
+      stream << "]}"
     end
   end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,8 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "f05306156f615c94740940841a2243116ea4b8a6ee371826c57b1c2eedec0c0b",
+      "note": "False positive. The interpolated values are: (1) properties_sql — built entirely from the GEOJSON_PROPERTY_COLUMNS constant, zero user input; (2) filtered_ids_sql — produced by ActiveRecord's parameterised query builder from apply_filters, which sanitises all user-supplied params before emitting SQL; (3) quoted — escaped via connection.quote(); (4) BATCH_SIZE — a Ruby integer constant."
+    }
+  ]
+}

--- a/spec/exporters/public_water_system_exporter_spec.rb
+++ b/spec/exporters/public_water_system_exporter_spec.rb
@@ -33,32 +33,42 @@ RSpec.describe PublicWaterSystemExporter do
     end
   end
 
-  describe "#to_geojson" do
-    it "returns a FeatureCollection hash" do
-      result = exporter.to_geojson
-      expect(result[:type]).to eq("FeatureCollection")
-      expect(result[:features]).to be_an(Array)
+  describe "#to_geojson_stream" do
+    # joins all streamed chunks and parses the result
+    subject(:geojson) { JSON.parse(exporter.to_geojson_stream.to_a.join) }
+
+    it "returns a FeatureCollection" do
+      expect(geojson["type"]).to eq("FeatureCollection")
+      expect(geojson["features"]).to be_an(Array)
     end
 
     it "includes one feature per system in the scope" do
-      create(:public_water_system)
-      scope = PublicWaterSystem.with_details
-      result = described_class.new(scope).to_geojson
-      expect(result[:features].length).to eq(2)
+      other = create(:public_water_system)
+      scope = PublicWaterSystem.where(pwsid: [pws.pwsid, other.pwsid])
+      result = JSON.parse(described_class.new(scope).to_geojson_stream.to_a.join)
+      expect(result["features"].length).to eq(2)
+    end
+
+    it "continues fetching across batch boundaries" do
+      stub_const("PublicWaterSystemExporter::BATCH_SIZE", 1)
+      other = create(:public_water_system)
+      scope = PublicWaterSystem.where(pwsid: [pws.pwsid, other.pwsid])
+      result = JSON.parse(described_class.new(scope).to_geojson_stream.to_a.join)
+      expect(result["features"].length).to eq(2)
     end
 
     it "includes pwsid in feature properties" do
-      feature = exporter.to_geojson[:features].first
-      expect(feature[:properties][:pwsid]).to eq(pws.pwsid)
+      feature = geojson["features"].first
+      expect(feature["properties"]["pwsid"]).to eq(pws.pwsid)
     end
 
     it "sets geometry to nil when service_area_geometry is not present" do
-      feature = exporter.to_geojson[:features].first
-      expect(feature[:geometry]).to be_nil
+      feature = geojson["features"].first
+      expect(feature["geometry"]).to be_nil
     end
 
     it "does not raise when associations are nil" do
-      expect { exporter.to_geojson }.not_to raise_error
+      expect { exporter.to_geojson_stream.to_a }.not_to raise_error
     end
   end
 end

--- a/spec/requests/exports_spec.rb
+++ b/spec/requests/exports_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 require "csv"
-require "zlib"
 
 RSpec.describe "Exports", type: :request do
   describe "GET /export" do
@@ -66,25 +65,23 @@ RSpec.describe "Exports", type: :request do
     end
 
     context "GeoJSON export" do
-      it "returns a gzip-compressed response with correct content headers" do
+      it "returns a response with correct content headers" do
         create(:public_water_system)
 
         get export_path, params: {file_format: "geojson"}
 
         expect(response).to have_http_status(:ok)
-        expect(response.headers["Content-Encoding"]).to eq("gzip")
-        expect(response.content_type).to eq("application/json")
+        expect(response.content_type).to include("application/json")
         expect(response.headers["Content-Disposition"]).to include("attachment")
         expect(response.headers["Content-Disposition"]).to include(".geojson")
       end
 
-      it "decompresses to a valid GeoJSON FeatureCollection" do
+      it "returns a valid GeoJSON FeatureCollection" do
         create(:public_water_system)
 
         get export_path, params: {file_format: "geojson"}
 
-        body = Zlib::GzipReader.new(StringIO.new(response.body)).read
-        geojson = JSON.parse(body)
+        geojson = JSON.parse(response.body)
         expect(geojson["type"]).to eq("FeatureCollection")
         expect(geojson["features"]).to be_an(Array)
         expect(geojson["features"].length).to eq(1)
@@ -95,8 +92,7 @@ RSpec.describe "Exports", type: :request do
 
         get export_path, params: {file_format: "geojson"}
 
-        body = Zlib::GzipReader.new(StringIO.new(response.body)).read
-        feature = JSON.parse(body)["features"].first
+        feature = JSON.parse(response.body)["features"].first
         expect(feature["properties"]["pwsid"]).to eq(pws.pwsid)
       end
 
@@ -106,8 +102,7 @@ RSpec.describe "Exports", type: :request do
 
         get export_path, params: {file_format: "geojson", state: "VT"}
 
-        body = Zlib::GzipReader.new(StringIO.new(response.body)).read
-        geojson = JSON.parse(body)
+        geojson = JSON.parse(response.body)
         expect(geojson["features"].length).to eq(1)
       end
     end


### PR DESCRIPTION
## Summary

Replaces the GeoJSON export path with a PostgreSQL-driven streaming implementation. The old approach loaded all matching records into Ruby, serialised properties in application code, and gzip-compressed the result before sending. The new approach pushes all serialisation into the database via `ST_AsGeoJSON` and `json_build_object`, streams the FeatureCollection to the client in cursor-keyed batches of 500, and eliminates the gzip layer entirely.

> In my experience playing around with it, this is FAST and can even export the entire data set in less than a minute

## Changes

- **Streaming GeoJSON export** — `to_geojson_stream` returns an Enumerator that yields JSON chunks directly to Rack, keeping memory usage flat for any result size. Records are fetched in keyset-paginated batches (`WHERE pwsid > $last`) rather than loaded all at once.
- **Database-side serialisation** — geometry encoding (`ST_AsGeoJSON`), property building (`jsonb_build_object`), and all JOIN logic run in PostgreSQL. Ruby no longer touches individual row values for GeoJSON output. `GEOJSON_PROPERTY_COLUMNS` constant centralises the column-to-property mapping.
- **Removed gzip compression** — `Content-Encoding: gzip` and the `ActiveSupport::Gzip` call are gone. The response streams uncompressed JSON; browsers and HTTP clients handle transfer encoding via standard `Accept-Encoding` negotiation.
- **Deferred `with_details` for GeoJSON** — the controller no longer eagerly loads all associations for GeoJSON exports, since the SQL query handles joins directly. `with_details` is still applied for CSV exports.
- **SQL safety hardening** — `properties_sql` uses `connection.quote` / `connection.quote_column_name` for all interpolated values; `each_slice` capped at 49 pairs to stay under PostgreSQL's 100-argument limit; `fetch_feature_batch` annotated with a safety comment; Brakeman false positive suppressed with a documented ignore entry.
- **Test coverage** — new batch-boundary regression test (stubs `BATCH_SIZE = 1` to exercise the pagination loop); fixed a fragile `.last` reference in an existing feature-count test; request specs updated to parse uncompressed JSON directly.

## Notes for reviewers

The Brakeman ignore entry (`config/brakeman.ignore`) suppresses a raw-SQL warning on `fetch_feature_batch`. The note in the ignore file explains why each interpolated fragment is safe — all values derive from frozen constants or ActiveRecord's parameterised query builder. Worth a quick read to confirm the reasoning holds.

The `properties_sql` result is memoised on the exporter instance, so the subquery SQL is built once per export. The `filtered_ids_sql` subquery is re-executed by PostgreSQL on every batch fetch, which is correct for correctness but worth noting if exports over very large filtered scopes show query-planning overhead in future.

## Related Ticket
https://github.com/Environmental-Policy-Innovation-Center/water-data-tool/issues/179

## Screenshot
<img width="1913" height="923" alt="Screenshot 2026-06-04 at 11 47 21 AM" src="https://github.com/user-attachments/assets/37ede029-7c0f-4ad3-92d8-52127e7dedc9" />
