### PR TITLE
[Fix] Broken Pipes for PR Teardown Action

### DIFF
--- a/.github/actions/teardown-pr/action.yml
+++ b/.github/actions/teardown-pr/action.yml
@@ -26,6 +26,44 @@ runs:
             --source-group "$NODE_SG_ID" || true
         fi
 
+    - name: Pre-drain ECS service before Terraform destroy
+      shell: bash
+      run: |
+        CLUSTER="ep_core__dev_us-east-1"
+        SERVICE="ep_app__water_data_tool_pr_${{ inputs.pr_number }}__dev_us-east-1"
+
+        STATUS=$(aws ecs describe-services \
+          --cluster "$CLUSTER" --services "$SERVICE" \
+          --query 'services[0].status' --output text 2>/dev/null || echo "MISSING")
+
+        if [ "$STATUS" != "ACTIVE" ]; then
+          echo "Service not ACTIVE (status: $STATUS) — skipping pre-drain."
+          exit 0
+        fi
+
+        echo "Setting desired count to 0..."
+        aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" \
+          --desired-count 0 > /dev/null
+
+        echo "Force-stopping all running tasks..."
+        TASKS=$(aws ecs list-tasks --cluster "$CLUSTER" \
+          --service-name "$SERVICE" --query 'taskArns[]' --output text)
+        for TASK in $TASKS; do
+          echo "  Stopping: $TASK"
+          aws ecs stop-task --cluster "$CLUSTER" --task "$TASK" \
+            --reason "PR teardown pre-drain" > /dev/null || true
+        done
+
+        echo "Waiting for running count to reach 0 (max 2 min)..."
+        for i in $(seq 1 24); do
+          RUNNING=$(aws ecs describe-services \
+            --cluster "$CLUSTER" --services "$SERVICE" \
+            --query 'services[0].runningCount' --output text)
+          [ "$RUNNING" = "0" ] && echo "All tasks stopped." && break
+          echo "  running: $RUNNING — waiting 5s ($i/24)..."
+          sleep 5
+        done
+
     - name: Destroy PR environment via service_builder
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

PR environment teardowns were consistently failing on the first attempt. Every `terraform destroy` run was timing out after 20 minutes waiting for the ECS service to reach `INACTIVE`. Investigation confirmed the cause: Terraform was destroying `aws_autoscaling_attachment` (which calls `DetachLoadBalancerTargetGroups`) in parallel with the ECS service drain, disrupting ECS's own `DeregisterTargets` call and causing the drain to stall indefinitely. This adds a pre-drain step that stops all tasks before handing off to `service_builder`, so Terraform has nothing left to wait for.

## Changes

- Add a pre-drain step to the PR teardown composite action that runs before `service_builder` destroys the environment
  - Sets the ECS service desired count to 0 and force-stops all running tasks via the AWS CLI
  - Polls until running count reaches 0 (up to 2 minutes) before proceeding
  - Skips gracefully if the service is already non-ACTIVE (safe for re-runs on previously attempted teardowns)

## Notes for reviewers

The root cause is a parallel destroy race in the Terraform module (in the infra repo): `aws_autoscaling_attachment` and `aws_ecs_service` have no dependency on each other, so Terraform runs them simultaneously. The `DetachLoadBalancerTargetGroups` call completes in ~0s and races against ECS's `DeregisterTargets`, leaving the drain in a broken state that never resolves. A corresponding fix (`aws_autoscaling_attachment` added to `aws_ecs_service.depends_on`) is being made in the infra repo separately.

This pre-drain step is the right fix regardless — even after the infra change lands, pre-draining means ECS's `DeleteService` completes in seconds rather than relying on the drain timeout at all.

8 orphaned DRAINING ECS services from previously failed teardowns (PRs 160, 166, 168, 177, 178, 182, 193, 201) were manually cleaned up as part of this investigation.
