### PR TITLE
[CHORE] Bump Puma to 7.2.1 to address CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "pagy", "~> 43.5.1"
 gem "pg", "~> 1.6.3"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 7.2.0"
+gem "puma", "~> 7.2.1"
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", "~> 0.1.20", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -519,7 +519,7 @@ DEPENDENCIES
   propshaft (~> 1.3.1)
   pry-byebug (~> 3.12.0)
   pry-rails (~> 0.3.11)
-  puma (~> 7.2.0)
+  puma (~> 7.2.1)
   rails (~> 8.1.3)
   rspec-rails (~> 8.0.4)
   shoulda-matchers (~> 7.0.1)


### PR DESCRIPTION
# Summary

This PR address two CVEs that were flagged in a recent gem audit, but bumping Puma to the patched version of **7.2.1**

```
Name: puma
Version: 7.2.0
CVE: CVE-2026-47736
GHSA: GHSA-qpgp-93vx-g8v8
Criticality: High
URL: https://www.cve.org/CVERecord?id=CVE-2026-47736
Title: Puma PROXY Protocol v1 Parser Allows Remote Memory Exhaustion
Solution: update to '~> 7.2.1', '>= 8.0.2'

Name: puma
Version: 7.2.0
CVE: CVE-2026-47737
GHSA: GHSA-2vqw-3mp8-cgmx
Criticality: High
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47737
Title: Puma PROXY Protocol v1 Accepts Repeated Protocol Headers on Persistent Connections
Solution: update to '~> 7.2.1', '>= 8.0.2'

Vulnerabilities found!
```