### PR TITLE
[Hotfix] Work Tile Cache Busting Logic into Recent Workflow Changes

### DIFF
--- a/.github/workflows/refresh-cartographic-boundaries.yml
+++ b/.github/workflows/refresh-cartographic-boundaries.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           OVERRIDES=$(jq -cn \
             --arg name "$CONTAINER_NAME" \
-            --arg code "CartographicBoundaries.load" \
+            --arg code "CartographicBoundaries.load; Etl::PostImportSteps.bust_cartographic_boundary_tile_cache; TileCacheWarmJob.perform_now(max_zoom: 5, layers: %w[states counties places])" \
             '{containerOverrides:[{name:$name, command:["./bin/rails","runner",$code]}]}')
 
           RUN_ARGS=(
@@ -169,7 +169,7 @@ jobs:
             exit 1
           fi
 
-      - name: Verify boundary row counts
+      - name: Verify boundary rows and low-zoom tiles
         id: verify
         timeout-minutes: 10
         env:
@@ -177,7 +177,7 @@ jobs:
           CONTAINER_NAME: ${{ steps.target.outputs.container_name }}
           PLACEMENT_CONSTRAINTS: ${{ steps.target.outputs.placement_constraints }}
         run: |
-          VERIFY_CODE='counts = {cartographic_states: CartographicState.count, cartographic_counties: CartographicCounty.count, cartographic_places: CartographicPlace.count}; puts counts.to_json; abort("Missing cartographic boundary rows: #{counts}") if counts.values.any?(&:zero?)'
+          VERIFY_CODE='counts = {cartographic_states: CartographicState.count, cartographic_counties: CartographicCounty.count, cartographic_places: CartographicPlace.count}; abort("Missing cartographic boundary rows: #{counts}") if counts.values.any?(&:zero?); tiles = {states_z3: TileGenerator.generate_tile("states", 3, 1, 3).bytesize, states_z4: TileGenerator.generate_tile("states", 4, 4, 6).bytesize, boundaries_z5: TileGenerator.generate_tile("counties", 5, 8, 12).bytesize}; abort("Empty boundary verification tile: #{tiles}") if tiles.values.any?(&:zero?); puts({counts: counts, tiles: tiles}.to_json)'
           OVERRIDES=$(jq -cn \
             --arg name "$CONTAINER_NAME" \
             --arg code "$VERIFY_CODE" \

--- a/app/jobs/tile_cache_warm_job.rb
+++ b/app/jobs/tile_cache_warm_job.rb
@@ -12,14 +12,14 @@ class TileCacheWarmJob < ApplicationJob
     [144, 13, 146, 16]  # Guam + CNMI
   ].freeze
 
-  def perform
+  def perform(max_zoom: MAX_WARM_ZOOM, layers: nil)
     total_start = Time.current
     total_coords = 0
 
-    log("[TileCacheWarm] Starting smart warm for z0-z#{MAX_WARM_ZOOM}")
+    log("[TileCacheWarm] Starting smart warm for z0-z#{max_zoom}")
 
-    (0..MAX_WARM_ZOOM).each do |z|
-      total_coords += warm_zoom(z)
+    (0..max_zoom).each do |z|
+      total_coords += warm_zoom(z, requested_layers: layers)
     end
 
     elapsed = (Time.current - total_start).round(1)
@@ -28,13 +28,14 @@ class TileCacheWarmJob < ApplicationJob
 
   private
 
-  def warm_zoom(z)
+  def warm_zoom(z, requested_layers: nil)
     started_at = Time.current
     errors = 0
     coords = tile_coordinates(z)
     total = coords.size
 
     layers = TileGenerator.layers_for_zoom(z)
+    layers &= requested_layers if requested_layers
 
     log("[TileCacheWarm] z#{z}: starting (#{total} coordinates, #{layers.size} layers each)")
 

--- a/app/services/etl/post_import_steps.rb
+++ b/app/services/etl/post_import_steps.rb
@@ -192,6 +192,11 @@ module Etl
       Rails.logger.info("[ETL] bust_tile_cache: deleted #{deleted} cached tile(s)")
     end
 
+    def bust_cartographic_boundary_tile_cache
+      deleted = TileCache.where(layer: %w[states counties places]).delete_all
+      Rails.logger.info("[ETL] bust_cartographic_boundary_tile_cache: deleted #{deleted} cached boundary tile(s)")
+    end
+
     # Rebuild GiST spatial indexes and update query-planner statistics after
     # a bulk geometry import. CONCURRENTLY avoids ACCESS EXCLUSIVE locks on
     # service_area_geometries while map requests continue using the old indexes.

--- a/spec/jobs/tile_cache_warm_job_spec.rb
+++ b/spec/jobs/tile_cache_warm_job_spec.rb
@@ -67,6 +67,46 @@ RSpec.describe TileCacheWarmJob, type: :job do
       expect(TileGenerator).to have_received(:generate_tile!).with("counties", 8, 0, 0)
       expect(TileGenerator).to have_received(:generate_tile!).with("states", 8, 0, 0)
     end
+
+    it "defaults to warming eligible layers through z8" do
+      allow_any_instance_of(described_class).to receive(:tile_coordinates).and_return([[0, 0]])
+
+      described_class.perform_now
+
+      expect(TileGenerator).to have_received(:generate_tile!).with("states", 0, 0, 0)
+      expect(TileGenerator).to have_received(:generate_tile!).with("states", 8, 0, 0)
+      expect(TileGenerator).not_to have_received(:generate_tile!).with(anything, 9, anything, anything)
+    end
+
+    it "does not warm zooms above max_zoom" do
+      allow_any_instance_of(described_class).to receive(:tile_coordinates).and_return([[0, 0]])
+
+      described_class.perform_now(max_zoom: 5)
+
+      expect(TileGenerator).to have_received(:generate_tile!).with("states", 5, 0, 0)
+      expect(TileGenerator).not_to have_received(:generate_tile!).with(anything, 6, anything, anything)
+    end
+
+    it "warms only requested layers when layers are provided" do
+      allow_any_instance_of(described_class).to receive(:tile_coordinates).and_return([[0, 0]])
+
+      described_class.perform_now(layers: %w[states counties places])
+
+      expect(TileGenerator).to have_received(:generate_tile!).with("states", 8, 0, 0)
+      expect(TileGenerator).to have_received(:generate_tile!).with("counties", 8, 0, 0)
+      expect(TileGenerator).to have_received(:generate_tile!).with("places", 8, 0, 0)
+      expect(TileGenerator).not_to have_received(:generate_tile!).with("pws", anything, anything, anything)
+    end
+
+    it "uses zoom eligibility after filtering requested layers" do
+      allow_any_instance_of(described_class).to receive(:tile_coordinates).and_return([[0, 0]])
+
+      described_class.perform_now(max_zoom: 5, layers: %w[states counties places])
+
+      expect(TileGenerator).to have_received(:generate_tile!).with("states", 5, 0, 0)
+      expect(TileGenerator).to have_received(:generate_tile!).with("counties", 5, 0, 0)
+      expect(TileGenerator).not_to have_received(:generate_tile!).with("places", 5, 0, 0)
+    end
   end
 
   describe "#tile_coordinates" do

--- a/spec/services/cartographic_boundaries_spec.rb
+++ b/spec/services/cartographic_boundaries_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe CartographicBoundaries do
         end
       end
 
+      it "does not bust or warm map tiles after a successful boundary refresh" do
+        expect(Etl::PostImportSteps).not_to receive(:bust_tile_cache)
+        expect(Etl::PostImportSteps).not_to receive(:bust_cartographic_boundary_tile_cache)
+        expect(TileCacheWarmJob).not_to receive(:perform_later)
+
+        instance.load
+      end
+
       private
 
       def stub_http_client

--- a/spec/services/etl/post_import_steps_spec.rb
+++ b/spec/services/etl/post_import_steps_spec.rb
@@ -107,6 +107,27 @@ RSpec.describe Etl::PostImportSteps do
     end
   end
 
+  describe ".bust_cartographic_boundary_tile_cache" do
+    it "deletes only boundary layer rows from the tile cache" do
+      create(:tile_cache, layer: "states", z: 3, x: 2, y: 1)
+      create(:tile_cache, layer: "counties", z: 5, x: 8, y: 12)
+      create(:tile_cache, layer: "places", z: 8, x: 76, y: 93)
+      pws = create(:tile_cache, layer: "pws", z: 5, x: 9, y: 12)
+
+      expect { described_class.bust_cartographic_boundary_tile_cache }
+        .to change { TileCache.count }.from(4).to(1)
+
+      expect(TileCache.pluck(:layer, :z, :x, :y)).to eq([[pws.layer, pws.z, pws.x, pws.y]])
+    end
+
+    it "runs without error when no boundary cache rows exist" do
+      create(:tile_cache, layer: "pws", z: 5, x: 8, y: 12)
+
+      expect { described_class.bust_cartographic_boundary_tile_cache }.not_to raise_error
+      expect(TileCache.pluck(:layer)).to eq(["pws"])
+    end
+  end
+
   describe ".call" do
     before do
       insert_state("VT", VERMONT_STATE_WKT)


### PR DESCRIPTION
## Summary

Refresh cartographic boundaries now performs targeted boundary tile cache maintenance instead of triggering a broad tile cache bust and full async warm. This keeps state/county/place tiles fresh for the boundary refresh workflow while preserving unrelated PWS tile cache entries.

## Changes

- Add scoped cartographic boundary cache invalidation for states, counties, and places while leaving PWS tiles intact.
- Allow tile warming to be constrained by max zoom and layer list, preserving the existing full z0-z8 defaults.
- Update the boundary refresh workflow to load boundaries, clear only cartographic boundary tiles, synchronously warm z0-z5 boundary tiles, and verify both row counts and representative low-zoom tile output before restoring service.
- Keep CartographicBoundaries.load focused on loading boundary tables without enqueueing cache work as a side effect.
- Cover the new warm-job options, boundary-only cache invalidation, and loader behavior with specs.

## Notes for reviewers

The workflow intentionally warms only z0-z5 synchronously. Higher-zoom boundary tiles regenerate on demand after service restore, while PWS tiles are preserved because boundary-only refreshes do not stale service-area geometry tiles.
