### PR TITLE
[FIX] Add Preview Environment support to Cartographic Boundary refresh

### DIFF
--- a/.github/workflows/refresh-cartographic-boundaries.yml
+++ b/.github/workflows/refresh-cartographic-boundaries.yml
@@ -12,12 +12,12 @@ on:
           - production
           - preview
       scale_service_down:
-        description: "Temporarily scale the web service to zero while the one-off task runs (staging/production only, ignored for preview)"
+        description: "Temporarily scale the staging web service to zero while the one-off task runs (required for preview; recommended for staging/production during off-hours)"
         required: true
         type: boolean
         default: false
       confirm:
-        description: 'Type "refresh-staging-boundaries", "refresh-production-boundaries", or "refresh-preview-boundaries"; append "-with-downtime" when scale_service_down is true (staging/production only)'
+        description: 'Type "refresh-staging-boundaries", "refresh-production-boundaries", or "refresh-preview-boundaries"; append "-with-downtime" when scale_service_down is true'
         required: true
 
 concurrency:
@@ -44,7 +44,7 @@ jobs:
       - name: Validate confirmation input
         run: |
           EXPECTED="refresh-${TARGET_ENV}-boundaries"
-          if [ "$TARGET_ENV" != "preview" ] && [ "$SCALE_SERVICE_DOWN" = "true" ]; then
+          if [ "$SCALE_SERVICE_DOWN" = "true" ]; then
             EXPECTED="${EXPECTED}-with-downtime"
           fi
 
@@ -101,10 +101,8 @@ jobs:
             --query 'services[0].placementConstraints' \
             --output json | jq -c .)
 
-          SCALEABLE="true"
           ENV_OVERRIDE="[]"
           if [ "$TARGET_ENV" = "preview" ]; then
-            SCALEABLE="false"
             DB_URL=$(aws secretsmanager get-secret-value \
               --secret-id "ep/wdt/dev/database_url" \
               --query 'SecretString' --output text | jq -r '.preview')
@@ -117,12 +115,11 @@ jobs:
             echo "container_name=$CONTAINER_NAME"
             echo "desired_count=$DESIRED_COUNT"
             echo "placement_constraints=$PLACEMENT_CONSTRAINTS"
-            echo "scaleable=$SCALEABLE"
             echo "env_override=$ENV_OVERRIDE"
           } >> "$GITHUB_OUTPUT"
 
       - name: Scale service down
-        if: github.event.inputs.scale_service_down == 'true' && steps.target.outputs.scaleable == 'true'
+        if: github.event.inputs.scale_service_down == 'true'
         run: |
           aws ecs update-service \
             --cluster "$ECS_CLUSTER" \
@@ -143,11 +140,20 @@ jobs:
           PLACEMENT_CONSTRAINTS: ${{ steps.target.outputs.placement_constraints }}
           ENV_OVERRIDE: ${{ steps.target.outputs.env_override }}
         run: |
-          OVERRIDES=$(jq -cn \
-            --arg name "$CONTAINER_NAME" \
-            --arg code "CartographicBoundaries.load; Etl::PostImportSteps.bust_cartographic_boundary_tile_cache; TileCacheWarmJob.perform_now(max_zoom: 5, layers: %w[states counties places])" \
-            --argjson env "$ENV_OVERRIDE" \
-            '{memory:"1024",containerOverrides:[{name:$name,command:["./bin/rails","runner",$code]} | if ($env | length) > 0 then . + {environment:$env} else . end]}')
+          DB_URL=$(jq -r '.[0].value // ""' <<< "$ENV_OVERRIDE")
+          RAILS_CMD="CartographicBoundaries.load; Etl::PostImportSteps.bust_cartographic_boundary_tile_cache; TileCacheWarmJob.perform_now(max_zoom: 5, layers: %w[states counties places])"
+          if [ -n "$DB_URL" ]; then
+            OVERRIDES=$(jq -cn \
+              --arg name "$CONTAINER_NAME" \
+              --arg code "$RAILS_CMD" \
+              --arg db_url "$DB_URL" \
+              '{memory:"512",containerOverrides:[{name:$name,memory:512,command:["env",("DATABASE_URL="+$db_url),"./bin/rails","runner",$code]}]}')
+          else
+            OVERRIDES=$(jq -cn \
+              --arg name "$CONTAINER_NAME" \
+              --arg code "$RAILS_CMD" \
+              '{memory:"512",containerOverrides:[{name:$name,memory:512,command:["./bin/rails","runner",$code]}]}')
+          fi
 
           RUN_ARGS=(
             --cluster "$ECS_CLUSTER"
@@ -170,19 +176,42 @@ jobs:
           fi
 
           echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
+          echo "Refresh task started: $TASK_ARN"
 
-          aws ecs wait tasks-stopped \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$TASK_ARN"
+          while true; do
+            TASK_DESCRIPTION=$(aws ecs describe-tasks \
+              --cluster "$ECS_CLUSTER" \
+              --tasks "$TASK_ARN")
+            STATUS=$(jq -r '.tasks[0].lastStatus // empty' <<< "$TASK_DESCRIPTION")
+            echo "$(date -u '+%H:%M:%S') status: $STATUS"
+            [ "$STATUS" = "STOPPED" ] && break
+            sleep 30
+          done
 
-          TASK_DESCRIPTION=$(aws ecs describe-tasks \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$TASK_ARN")
           EXIT_CODE=$(jq -r '.tasks[0].containers[0].exitCode // empty' <<< "$TASK_DESCRIPTION")
+
+          LOG_GROUP=$(aws ecs describe-task-definition \
+            --task-definition "$TASK_DEF" \
+            --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-group"' \
+            --output text)
+          LOG_PREFIX=$(aws ecs describe-task-definition \
+            --task-definition "$TASK_DEF" \
+            --query 'taskDefinition.containerDefinitions[0].logConfiguration.options."awslogs-stream-prefix"' \
+            --output text)
+          TASK_ID="${TASK_ARN##*/}"
+          LOG_STREAM="${LOG_PREFIX}/${CONTAINER_NAME}/${TASK_ID}"
 
           if [ "$EXIT_CODE" != "0" ]; then
             echo "::error::Boundary refresh task exited with code $EXIT_CODE. Task: $TASK_ARN"
             jq '.tasks[0].containers[0] | {name, lastStatus, exitCode, reason}' <<< "$TASK_DESCRIPTION"
+            echo "--- CloudWatch logs ---"
+            sleep 5
+            aws logs get-log-events \
+              --log-group-name "$LOG_GROUP" \
+              --log-stream-name "$LOG_STREAM" \
+              --start-from-head \
+              --query 'events[*].message' \
+              --output text || true
             exit 1
           fi
 
@@ -197,11 +226,19 @@ jobs:
         run: |
           VERIFY_CODE='counts = {cartographic_states: CartographicState.count, cartographic_counties: CartographicCounty.count, cartographic_places: CartographicPlace.count}; abort("Missing cartographic boundary rows: #{counts}") if counts.values.any?(&:zero?); tiles = {states_z3: TileGenerator.generate_tile("states", 3, 1, 3).bytesize, states_z4: TileGenerator.generate_tile("states", 4, 4, 6).bytesize, boundaries_z5: TileGenerator.generate_tile("counties", 5, 8, 12).bytesize}; abort("Empty boundary verification tile: #{tiles}") if tiles.values.any?(&:zero?); puts({counts: counts, tiles: tiles}.to_json)'
 
-          OVERRIDES=$(jq -cn \
-            --arg name "$CONTAINER_NAME" \
-            --arg code "$VERIFY_CODE" \
-            --argjson env "$ENV_OVERRIDE" \
-            '{memory:"1024",containerOverrides:[{name:$name,command:["./bin/rails","runner",$code]} | if ($env | length) > 0 then . + {environment:$env} else . end]}')
+          DB_URL=$(jq -r '.[0].value // ""' <<< "$ENV_OVERRIDE")
+          if [ -n "$DB_URL" ]; then
+            OVERRIDES=$(jq -cn \
+              --arg name "$CONTAINER_NAME" \
+              --arg code "$VERIFY_CODE" \
+              --arg db_url "$DB_URL" \
+              '{memory:"512",containerOverrides:[{name:$name,memory:512,command:["env",("DATABASE_URL="+$db_url),"./bin/rails","runner",$code]}]}')
+          else
+            OVERRIDES=$(jq -cn \
+              --arg name "$CONTAINER_NAME" \
+              --arg code "$VERIFY_CODE" \
+              '{memory:"512",containerOverrides:[{name:$name,memory:512,command:["./bin/rails","runner",$code]}]}')
+          fi
 
           RUN_ARGS=(
             --cluster "$ECS_CLUSTER"
@@ -224,14 +261,18 @@ jobs:
           fi
 
           echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
+          echo "Verify task started: $TASK_ARN"
 
-          aws ecs wait tasks-stopped \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$TASK_ARN"
+          while true; do
+            TASK_DESCRIPTION=$(aws ecs describe-tasks \
+              --cluster "$ECS_CLUSTER" \
+              --tasks "$TASK_ARN")
+            STATUS=$(jq -r '.tasks[0].lastStatus // empty' <<< "$TASK_DESCRIPTION")
+            echo "$(date -u '+%H:%M:%S') status: $STATUS"
+            [ "$STATUS" = "STOPPED" ] && break
+            sleep 30
+          done
 
-          TASK_DESCRIPTION=$(aws ecs describe-tasks \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$TASK_ARN")
           EXIT_CODE=$(jq -r '.tasks[0].containers[0].exitCode // empty' <<< "$TASK_DESCRIPTION")
 
           if [ "$EXIT_CODE" != "0" ]; then
@@ -257,7 +298,7 @@ jobs:
             --log-stream-name "$LOG_STREAM" \
             --start-from-head \
             --query 'events[*].message' \
-            --output text)
+            --output text 2>/dev/null || echo "")
 
           DELIM=$(openssl rand -hex 8)
           {
@@ -267,7 +308,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Restore service desired count
-        if: always() && github.event.inputs.scale_service_down == 'true' && steps.target.outputs.scaleable == 'true' && steps.target.outputs.service != '' && steps.target.outputs.desired_count != ''
+        if: always() && github.event.inputs.scale_service_down == 'true' && steps.target.outputs.service != '' && steps.target.outputs.desired_count != ''
         run: |
           aws ecs update-service \
             --cluster "$ECS_CLUSTER" \

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -106,8 +106,8 @@ Use **Actions → Refresh Cartographic Boundaries → Run workflow** to reload t
 | Input | Description |
 |---|---|
 | `target_environment` | `staging`, `production`, or `preview` |
-| `scale_service_down` | Scale the web service to zero while the task runs (staging/production only; ignored for preview) |
-| `confirm` | Type `refresh-<env>-boundaries` exactly. Append `-with-downtime` if `scale_service_down` is true. |
+| `scale_service_down` | Scale the staging web service to zero while the task runs. Required for preview (the constrained instances don't have enough free memory otherwise); optional for staging/production. |
+| `confirm` | Type `refresh-<env>-boundaries` exactly. Append `-with-downtime` if `scale_service_down` is true (e.g. `refresh-preview-boundaries-with-downtime`). |
 
 **How it works:**
 


### PR DESCRIPTION
## Summary
  
### Context

#229 

PR preview environments share the staging ECS cluster but write to a separate `water_data_tool_preview` database. The cartographic boundary refresh workflow previously only supported staging and production — this PR adds preview support.

Because preview borrows the staging task definition and placement constraints, the one-off task competes for memory on the same EC2 instances as the staging service. The fix is to allow `scale_service_down` for preview (previously ignored), which temporarily takes staging to zero, freeing enough memory for the task to run on the correct instances. Staging is restored automatically when the task finishes.

A full DB copy from production isn't used because preview only needs boundary geometries, not PWS data — the boundary refresh is the targeted, minimal operation.

### Changes

Key fixes discovered during testing:
  - `DATABASE_URL` must be injected via `env` command prefix — ECS secrets in the task definition override
  `containerOverrides.environment`, so the standard override mechanism doesn't work
  - Container-level memory must match task-level memory or ECS rejects the run
  - Placement constraints must be preserved (not cleared) to ensure the task lands on instances with RDS network access

Also adds 30s status polling, CloudWatch log fetching on failure, and updates `DEPLOYMENTS.md`.

## Test plan

  - [x] Ran against `preview` with `scale_service_down: true` — all three boundary layers loaded, tile cache warmed through z5,
  verify step passed
  - [x] Staging and production paths unchanged