### PR TITLE
[Hotfix] Issues with National-Level Tile Generation Causing Failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     css_parser (3.0.0)
       addressable
       ssrf_filter (~> 1.5)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ bin/dev
 # Run tests
 bundle exec rspec
 
+# Run the deterministic project CI
+bin/ci
+
+# Optional local pre-merge tile performance guard
+bin/rails runner bin/benchmark-tiles
+
 # Lint (check only — same tools as Lefthook pre-commit; no Git hook required)
 bin/standardrb
 bin/erb_lint --lint-all
@@ -202,6 +208,23 @@ bin/rails runner "TileCacheWarmJob.perform_now"
 ```
 
 This blocks until all z0-z8 tiles are generated. Progress is logged to stdout.
+
+### Local performance checks
+
+Keep `bin/ci` as the deterministic pre-merge baseline. When a change touches map tiles, spatial SQL, or cache behavior, run the safe tile performance guard after CI:
+
+```bash
+bin/ci
+bin/rails runner bin/benchmark-tiles
+```
+
+Benchmark scripts have different cache behavior:
+
+| Script | Purpose | Cache behavior |
+|---|---|---|
+| `bin/benchmark` | Broad query benchmarking for filters, stats, table loads, search, and warm tile retrieval by zoom tier | Non-destructive |
+| `bin/benchmark-tiles` | Safe local regression gate for tile SQL at overview, state-selection, and system-browsing zooms | Non-destructive; cold timings call `TileGenerator.generate_layer` directly |
+| `bin/benchmark-cold` | Manual cold-cache investigation for full tile generation | Destructive; deletes all rows from `tile_cache` before measuring |
 
 ---
 

--- a/app/models/service_area_geometry.rb
+++ b/app/models/service_area_geometry.rb
@@ -6,6 +6,10 @@
 #  centroid    :geometry         point, 4326
 #  geom        :geometry         multipolygon, 4326
 #  geom_digest :string
+#  geom_z0_4   :geometry         multipolygon, 4326
+#  geom_z5     :geometry         multipolygon, 4326
+#  geom_z6     :geometry         multipolygon, 4326
+#  geom_z7     :geometry         multipolygon, 4326
 #  pwsid       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -15,6 +19,10 @@
 #  index_service_area_geometries_on_centroid     (centroid) USING gist
 #  index_service_area_geometries_on_geom         (geom) USING gist
 #  index_service_area_geometries_on_geom_digest  (geom_digest)
+#  index_service_area_geometries_on_geom_z0_4    (geom_z0_4) USING gist
+#  index_service_area_geometries_on_geom_z5      (geom_z5) USING gist
+#  index_service_area_geometries_on_geom_z6      (geom_z6) USING gist
+#  index_service_area_geometries_on_geom_z7      (geom_z7) USING gist
 #  index_service_area_geometries_on_pwsid        (pwsid) UNIQUE
 #
 class ServiceAreaGeometry < ApplicationRecord

--- a/app/models/service_area_geometry.rb
+++ b/app/models/service_area_geometry.rb
@@ -19,10 +19,6 @@
 #  index_service_area_geometries_on_centroid     (centroid) USING gist
 #  index_service_area_geometries_on_geom         (geom) USING gist
 #  index_service_area_geometries_on_geom_digest  (geom_digest)
-#  index_service_area_geometries_on_geom_z0_4    (geom_z0_4) USING gist
-#  index_service_area_geometries_on_geom_z5      (geom_z5) USING gist
-#  index_service_area_geometries_on_geom_z6      (geom_z6) USING gist
-#  index_service_area_geometries_on_geom_z7      (geom_z7) USING gist
 #  index_service_area_geometries_on_pwsid        (pwsid) UNIQUE
 #
 class ServiceAreaGeometry < ApplicationRecord

--- a/app/services/etl/post_import_steps.rb
+++ b/app/services/etl/post_import_steps.rb
@@ -144,10 +144,7 @@ module Etl
       sql = <<~SQL
         UPDATE service_area_geometries
         SET
-          geom_z0_4 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.05)),
-          geom_z5 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.01)),
-          geom_z6 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.005)),
-          geom_z7 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.001)),
+          #{TileGenerator::GENERALIZED_GEOMETRY_ASSIGNMENTS_ON_GEOM_SQL},
           updated_at = NOW()
         WHERE geom IS NOT NULL
       SQL
@@ -171,20 +168,14 @@ module Etl
             FROM service_area_geometries
             WHERE geom IS NOT NULL
               AND (
-                geom_z0_4 IS NULL
-                OR geom_z5 IS NULL
-                OR geom_z6 IS NULL
-                OR geom_z7 IS NULL
+                #{TileGenerator::GENERALIZED_GEOMETRY_MISSING_SQL}
               )
             ORDER BY id
             LIMIT #{GENERALIZED_GEOMETRY_BACKFILL_BATCH_SIZE}
           )
           UPDATE service_area_geometries sag
           SET
-            geom_z0_4 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.05)),
-            geom_z5 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.01)),
-            geom_z6 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.005)),
-            geom_z7 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.001)),
+            #{TileGenerator::GENERALIZED_GEOMETRY_ASSIGNMENTS_ON_SAG_GEOM_SQL},
             updated_at = NOW()
           FROM rows_to_update
           WHERE sag.id = rows_to_update.id

--- a/app/services/etl/post_import_steps.rb
+++ b/app/services/etl/post_import_steps.rb
@@ -13,6 +13,8 @@ module Etl
 
       validate_import_results!(import_results)
 
+      backfill_missing_generalized_geometries
+
       return if import_results.empty?
 
       return legacy_call(import_results.map(&:file_key)) if import_results.any?(&:full_refresh_required)
@@ -26,6 +28,7 @@ module Etl
       if geometry_pwsids.any?
         fix_invalid_geometries(pwsids: geometry_pwsids)
         generate_centroids(pwsids: geometry_pwsids)
+        generate_generalized_geometries(pwsids: geometry_pwsids)
         CartographicBoundaries.load
         assign_state_codes(pwsids: geometry_pwsids)
         analyze_spatial_tables
@@ -92,6 +95,7 @@ module Etl
       # Tee up initial geoms repair and enrichment steps before refreshing
       fix_invalid_geometries
       generate_centroids
+      generate_generalized_geometries
       CartographicBoundaries.load
 
       # Assign state codes and county associations based on the new geometries,
@@ -106,6 +110,7 @@ module Etl
     # Repair invalid geometries using ST_Buffer trick. Runs until none remain
     # or until MAX_REPAIR_ITERATIONS is reached (guard against pathological data).
     MAX_REPAIR_ITERATIONS = 10
+    GENERALIZED_GEOMETRY_BACKFILL_BATCH_SIZE = 500
 
     def fix_invalid_geometries(pwsids: nil)
       all_valid = false
@@ -133,6 +138,69 @@ module Etl
       updated = scope.update_all("centroid = ST_PointOnSurface(geom)")
 
       Rails.logger.info("[ETL] generate_centroids: updated #{updated} row(s)")
+    end
+
+    def generate_generalized_geometries(pwsids: nil)
+      sql = <<~SQL
+        UPDATE service_area_geometries
+        SET
+          geom_z0_4 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.05)),
+          geom_z5 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.01)),
+          geom_z6 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.005)),
+          geom_z7 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.001)),
+          updated_at = NOW()
+        WHERE geom IS NOT NULL
+      SQL
+      sql << " AND pwsid = ANY($1::text[])" if pwsids.present?
+
+      updated = ApplicationRecord.connection.exec_update(
+        sql,
+        "PostImportSteps#generate_generalized_geometries",
+        pwsid_binds(pwsids)
+      )
+      Rails.logger.info("[ETL] generate_generalized_geometries: updated #{updated} row(s)")
+    end
+
+    def backfill_missing_generalized_geometries
+      total_updated = 0
+
+      loop do
+        sql = <<~SQL
+          WITH rows_to_update AS (
+            SELECT id
+            FROM service_area_geometries
+            WHERE geom IS NOT NULL
+              AND (
+                geom_z0_4 IS NULL
+                OR geom_z5 IS NULL
+                OR geom_z6 IS NULL
+                OR geom_z7 IS NULL
+              )
+            ORDER BY id
+            LIMIT #{GENERALIZED_GEOMETRY_BACKFILL_BATCH_SIZE}
+          )
+          UPDATE service_area_geometries sag
+          SET
+            geom_z0_4 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.05)),
+            geom_z5 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.01)),
+            geom_z6 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.005)),
+            geom_z7 = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, 0.001)),
+            updated_at = NOW()
+          FROM rows_to_update
+          WHERE sag.id = rows_to_update.id
+        SQL
+
+        updated = ApplicationRecord.connection.exec_update(
+          sql,
+          "PostImportSteps#backfill_missing_generalized_geometries"
+        )
+        total_updated += updated
+        Rails.logger.info("[ETL] backfill_missing_generalized_geometries: updated #{total_updated} row(s)") if updated.positive?
+        break if updated < GENERALIZED_GEOMETRY_BACKFILL_BATCH_SIZE
+      end
+
+      analyze_spatial_tables if total_updated.positive?
+      Rails.logger.info("[ETL] backfill_missing_generalized_geometries: complete, updated #{total_updated} row(s)")
     end
 
     # Join centroids to cartographic_states to assign the stusps code.

--- a/app/services/tile_benchmark.rb
+++ b/app/services/tile_benchmark.rb
@@ -1,0 +1,244 @@
+require "timeout"
+
+module TileBenchmark
+  Budget = Data.define(:tier, :warn_ms, :fail_ms, :db_timeout_ms)
+  Sample = Data.define(:z, :x, :y)
+  Result = Data.define(:mode, :layer, :sample, :tier, :elapsed_ms, :size_bytes, :status, :message) do
+    def timeout?
+      status == :timeout
+    end
+  end
+  Report = Data.define(:results) do
+    def exit_status
+      failing_results? ? 1 : 0
+    end
+
+    def failing_results?
+      results.any? { |result| %i[fail timeout].include?(result.status) }
+    end
+  end
+
+  DEFAULT_SAMPLES = [
+    Sample.new(z: 2, x: 0, y: 1),
+    Sample.new(z: 5, x: 9, y: 12),
+    Sample.new(z: 8, x: 59, y: 95)
+  ].freeze
+
+  module_function
+
+  def budget_for(z, env: ENV)
+    case z
+    when 0..4
+      Budget.new(
+        tier: "overview",
+        warn_ms: env.fetch("TILE_BENCH_WARN_MS_Z0_4", "3000").to_i,
+        fail_ms: env.fetch("TILE_BENCH_FAIL_MS_Z0_4", "8000").to_i,
+        db_timeout_ms: env.fetch("TILE_BENCH_DB_TIMEOUT_MS_Z0_4", env.fetch("TILE_BENCH_DB_TIMEOUT_MS", "10000")).to_i
+      )
+    when 5..7
+      Budget.new(
+        tier: "state selection",
+        warn_ms: env.fetch("TILE_BENCH_WARN_MS_Z5_7", "2000").to_i,
+        fail_ms: env.fetch("TILE_BENCH_FAIL_MS_Z5_7", "6000").to_i,
+        db_timeout_ms: env.fetch("TILE_BENCH_DB_TIMEOUT_MS_Z5_7", env.fetch("TILE_BENCH_DB_TIMEOUT_MS", "8000")).to_i
+      )
+    else
+      Budget.new(
+        tier: "system browsing",
+        warn_ms: env.fetch("TILE_BENCH_WARN_MS_Z8_PLUS", "1000").to_i,
+        fail_ms: env.fetch("TILE_BENCH_FAIL_MS_Z8_PLUS", "4000").to_i,
+        db_timeout_ms: env.fetch("TILE_BENCH_DB_TIMEOUT_MS_Z8_PLUS", env.fetch("TILE_BENCH_DB_TIMEOUT_MS", "6000")).to_i
+      )
+    end
+  end
+
+  def warm_budget(env: ENV)
+    Budget.new(
+      tier: "warm cache",
+      warn_ms: env.fetch("TILE_BENCH_WARN_MS_WARM", "200").to_i,
+      fail_ms: env.fetch("TILE_BENCH_FAIL_MS_WARM", "1000").to_i,
+      db_timeout_ms: 0
+    )
+  end
+
+  def expected_layers(z, tile_generator: TileGenerator)
+    tile_generator.layers_for_zoom(z)
+  end
+
+  class Runner
+    def initialize(samples: DEFAULT_SAMPLES, output: $stdout, tile_generator: TileGenerator, cache_model: TileCache, clock: nil, env: ENV, connection: nil)
+      @samples = samples
+      @output = output
+      @tile_generator = tile_generator
+      @cache_model = cache_model
+      @clock = clock || MonotonicClock
+      @env = env
+      @connection = connection
+    end
+
+    def run
+      puts_line "Tile Benchmark Guard"
+      puts_line "Cold timings use TileGenerator.generate_layer and do not write tile_cache."
+      puts_line ""
+
+      results = []
+      @samples.each do |sample|
+        expected_layers = TileBenchmark.expected_layers(sample.z, tile_generator: @tile_generator)
+        budget = TileBenchmark.budget_for(sample.z, env: @env)
+        puts_line format("z=%<z>d x=%<x>d y=%<y>d  tier=%<tier>s  expected_layers=%<count>d (%<layers>s)",
+          z: sample.z,
+          x: sample.x,
+          y: sample.y,
+          tier: budget.tier,
+          count: expected_layers.count,
+          layers: expected_layers.join(","))
+
+        cold_layers(sample.z, expected_layers).each do |layer|
+          result = measure_cold_layer(sample, layer, budget)
+          results << result
+          print_result(result)
+        end
+
+        warm_result = measure_warm_tile(sample, expected_layers)
+        if warm_result
+          results << warm_result
+          print_result(warm_result)
+        else
+          puts_line "  warm build_tile skipped: cached layers missing"
+        end
+
+        puts_line ""
+      end
+
+      report = Report.new(results: results)
+      puts_line(report.exit_status.zero? ? "PASS: all measured tile samples are within fail budgets" : "FAIL: one or more tile samples exceeded fail budgets")
+      report
+    end
+
+    private
+
+    def cold_layers(z, expected_layers)
+      return expected_layers if z >= 8
+
+      expected_layers.include?("pws") ? ["pws"] : expected_layers
+    end
+
+    def measure_cold_layer(sample, layer, budget)
+      elapsed_ms = nil
+      tile = "".b
+
+      begin
+        elapsed_ms = measure_ms do
+          with_db_statement_timeout(budget.db_timeout_ms) do
+            Timeout.timeout(budget.db_timeout_ms / 1000.0) do
+              tile = @tile_generator.generate_layer(
+                layer,
+                sample.z,
+                sample.x,
+                sample.y,
+                @tile_generator.layer_simplification_tolerance(layer, sample.z)
+              )
+            end
+          end
+        end
+      rescue Timeout::Error
+        elapsed_ms ||= budget.db_timeout_ms
+        return Result.new(mode: :cold, layer: layer, sample: sample, tier: budget.tier, elapsed_ms: elapsed_ms.round, size_bytes: 0, status: :timeout, message: "timed out at #{budget.db_timeout_ms}ms")
+      end
+
+      Result.new(
+        mode: :cold,
+        layer: layer,
+        sample: sample,
+        tier: budget.tier,
+        elapsed_ms: elapsed_ms.round,
+        size_bytes: tile.to_s.bytesize,
+        status: cold_status_for(elapsed_ms, budget),
+        message: cold_budget_message(elapsed_ms, budget)
+      )
+    end
+
+    def measure_warm_tile(sample, expected_layers)
+      cached_count = @cache_model.where(z: sample.z, x: sample.x, y: sample.y).count
+      return nil unless cached_count >= expected_layers.count
+
+      budget = TileBenchmark.warm_budget(env: @env)
+      tile = "".b
+      elapsed_ms = measure_ms { tile = @tile_generator.build_tile(sample.z, sample.x, sample.y) }
+
+      Result.new(
+        mode: :warm,
+        layer: "all",
+        sample: sample,
+        tier: budget.tier,
+        elapsed_ms: elapsed_ms.round,
+        size_bytes: tile.to_s.bytesize,
+        status: status_for(elapsed_ms, budget),
+        message: budget_message(elapsed_ms, budget)
+      )
+    end
+
+    def with_db_statement_timeout(timeout_ms)
+      return yield unless @connection
+
+      @connection.transaction(requires_new: true) do
+        @connection.execute("SET LOCAL statement_timeout = #{Integer(timeout_ms)}")
+        yield
+      end
+    end
+
+    def measure_ms
+      started = @clock.monotonic
+      yield
+      (@clock.monotonic - started) * 1000
+    end
+
+    def status_for(elapsed_ms, budget)
+      return :fail if elapsed_ms > budget.fail_ms
+      return :warn if elapsed_ms > budget.warn_ms
+
+      :pass
+    end
+
+    def cold_status_for(elapsed_ms, budget)
+      return :timeout if elapsed_ms >= budget.db_timeout_ms
+
+      status_for(elapsed_ms, budget)
+    end
+
+    def budget_message(elapsed_ms, budget)
+      return "over fail budget #{budget.fail_ms}ms" if elapsed_ms > budget.fail_ms
+      return "over warn budget #{budget.warn_ms}ms" if elapsed_ms > budget.warn_ms
+
+      "within budget"
+    end
+
+    def cold_budget_message(elapsed_ms, budget)
+      return "timed out at #{budget.db_timeout_ms}ms" if elapsed_ms >= budget.db_timeout_ms
+
+      budget_message(elapsed_ms, budget)
+    end
+
+    def print_result(result)
+      puts_line format("  %-5s %-8s %6dms %7.1f KB  %-7s %s",
+        result.mode,
+        result.layer,
+        result.elapsed_ms,
+        result.size_bytes / 1024.0,
+        result.status.to_s.upcase,
+        result.message)
+    end
+
+    def puts_line(text)
+      @output.puts(text)
+    end
+  end
+
+  module MonotonicClock
+    module_function
+
+    def monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/app/services/tile_benchmark.rb
+++ b/app/services/tile_benchmark.rb
@@ -14,7 +14,7 @@ module TileBenchmark
     end
 
     def failing_results?
-      results.any? { |result| %i[fail timeout].include?(result.status) }
+      results.any? { |result| %i[error fail timeout].include?(result.status) }
     end
   end
 
@@ -65,6 +65,12 @@ module TileBenchmark
     tile_generator.layers_for_zoom(z)
   end
 
+  def expected_cache_layers(z, tile_generator: TileGenerator)
+    expected_layers(z, tile_generator: tile_generator).map do |layer|
+      tile_generator.respond_to?(:cache_layer) ? tile_generator.cache_layer(layer, z) : layer
+    end
+  end
+
   class Runner
     def initialize(samples: DEFAULT_SAMPLES, output: $stdout, tile_generator: TileGenerator, cache_model: TileCache, clock: nil, env: ENV, connection: nil)
       @samples = samples
@@ -78,7 +84,7 @@ module TileBenchmark
 
     def run
       puts_line "Tile Benchmark Guard"
-      puts_line "Cold timings use TileGenerator.generate_layer and do not write tile_cache."
+      puts_line "Cold timings use TileGenerator.generate_layer! and do not write tile_cache."
       puts_line ""
 
       results = []
@@ -131,7 +137,7 @@ module TileBenchmark
         elapsed_ms = measure_ms do
           with_db_statement_timeout(budget.db_timeout_ms) do
             Timeout.timeout(budget.db_timeout_ms / 1000.0) do
-              tile = @tile_generator.generate_layer(
+              tile = @tile_generator.generate_layer!(
                 layer,
                 sample.z,
                 sample.x,
@@ -144,6 +150,9 @@ module TileBenchmark
       rescue Timeout::Error
         elapsed_ms ||= budget.db_timeout_ms
         return Result.new(mode: :cold, layer: layer, sample: sample, tier: budget.tier, elapsed_ms: elapsed_ms.round, size_bytes: 0, status: :timeout, message: "timed out at #{budget.db_timeout_ms}ms")
+      rescue ActiveRecord::StatementInvalid => e
+        elapsed_ms ||= 0
+        return Result.new(mode: :cold, layer: layer, sample: sample, tier: budget.tier, elapsed_ms: elapsed_ms.round, size_bytes: 0, status: :error, message: "sql error: #{e.message}")
       end
 
       Result.new(
@@ -159,8 +168,9 @@ module TileBenchmark
     end
 
     def measure_warm_tile(sample, expected_layers)
-      cached_count = @cache_model.where(z: sample.z, x: sample.x, y: sample.y).count
-      return nil unless cached_count >= expected_layers.count
+      cached_layers = @cache_model.where(z: sample.z, x: sample.x, y: sample.y).pluck(:layer)
+      expected_cache_layers = TileBenchmark.expected_cache_layers(sample.z, tile_generator: @tile_generator)
+      return nil unless (expected_cache_layers - cached_layers).empty?
 
       budget = TileBenchmark.warm_budget(env: @env)
       tile = "".b

--- a/app/services/tile_generator.rb
+++ b/app/services/tile_generator.rb
@@ -126,7 +126,7 @@ module TileGenerator
         FROM (
           SELECT
             ST_AsMVTGeom(
-              ST_Transform(ST_SimplifyPreserveTopology(sag.geom, #{simp}), 3857),
+              ST_Transform(#{pws_geometry_sql(z, simp)}, 3857),
               #{tile_envelope}, #{EXTENT}, #{BUFFER}, true
             ) AS mvtgeom,
             #{attrs}
@@ -195,6 +195,18 @@ module TileGenerator
     return "ST_TileEnvelope(#{z}, #{x}, #{y}, margin => #{BUFFER}.0 / #{EXTENT})" if margin
 
     "ST_TileEnvelope(#{z}, #{x}, #{y})"
+  end
+
+  def pws_geometry_sql(z, simp)
+    column = case z
+    when 0..4 then "geom_z0_4"
+    when 5 then "geom_z5"
+    when 6 then "geom_z6"
+    when 7 then "geom_z7"
+    end
+    fallback = "ST_SimplifyPreserveTopology(sag.geom, #{simp})"
+
+    column ? "COALESCE(sag.#{column}, #{fallback})" : fallback
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/services/tile_generator.rb
+++ b/app/services/tile_generator.rb
@@ -4,6 +4,7 @@ module TileGenerator
   BUFFER = 64
   PWS_MIN_ZOOM = 5
   PLACES_MIN_ZOOM = 8
+  LOW_ZOOM_PWS_CACHE_LAYER = "pws_low_poly_v1"
 
   # Simplification tolerances keyed by max zoom level.
   SIMPLIFICATION = [
@@ -39,14 +40,12 @@ module TileGenerator
   end
 
   def layer_simplification_tolerance(layer, z)
-    return simplification_tolerance(PWS_MIN_ZOOM) if layer == "pws" && z == PWS_MIN_ZOOM - 1
-
     simplification_tolerance(z)
   end
 
   # Generate (or fetch from cache) a single layer tile.
   def generate_tile(layer, z, x, y)
-    cached = TileCache.find_by(layer: layer, z: z, x: x, y: y)
+    cached = TileCache.find_by(layer: cache_layer(layer, z), z: z, x: x, y: y)
     return cached.mvt.to_s if cached
 
     generate_tile!(layer, z, x, y)
@@ -66,8 +65,9 @@ module TileGenerator
     cached = TileCache.where(z: z, x: x, y: y).index_by(&:layer)
 
     layers_for_zoom(z).each_with_object("".b) do |layer, result|
-      mvt = if cached[layer]
-        cached[layer].mvt.to_s
+      cache_key = cache_layer(layer, z)
+      mvt = if cached[cache_key]
+        cached[cache_key].mvt.to_s
       else
         simp = layer_simplification_tolerance(layer, z)
         generated = generate_layer(layer, z, x, y, simp)
@@ -95,7 +95,7 @@ module TileGenerator
 
   def persist_tile(layer, z, x, y, mvt_data)
     TileCache.upsert(
-      {layer: layer, z: z, x: x, y: y, mvt: mvt_data},
+      {layer: cache_layer(layer, z), z: z, x: x, y: y, mvt: mvt_data},
       unique_by: %i[layer z x y]
     )
   rescue ActiveRecord::RecordNotUnique
@@ -111,6 +111,16 @@ module TileGenerator
 
     case layer
     when "pws"
+      attrs = if z < PWS_MIN_ZOOM
+        "pws.pwsid, pws.stusps"
+      else
+        <<~SQL.squish
+          pws.pwsid, pws.stusps, pws.pws_name, pws.symbology_field,
+          pws.pop_cat_5, pws.population_served_count, pws.service_connections_count,
+          pws.area_sq_miles
+        SQL
+      end
+
       <<~SQL.squish
         SELECT ST_AsMVT(t, 'pws', #{EXTENT}, 'mvtgeom') AS mvt
         FROM (
@@ -119,9 +129,7 @@ module TileGenerator
               ST_Transform(ST_SimplifyPreserveTopology(sag.geom, #{simp}), 3857),
               #{tile_envelope}, #{EXTENT}, #{BUFFER}, true
             ) AS mvtgeom,
-            pws.pwsid, pws.stusps, pws.pws_name, pws.symbology_field,
-            pws.pop_cat_5, pws.population_served_count, pws.service_connections_count,
-            pws.area_sq_miles
+            #{attrs}
           FROM service_area_geometries sag
           JOIN public_water_systems pws ON pws.pwsid = sag.pwsid
           WHERE sag.geom IS NOT NULL
@@ -189,4 +197,10 @@ module TileGenerator
     "ST_TileEnvelope(#{z}, #{x}, #{y})"
   end
   # rubocop:enable Metrics/MethodLength
+
+  def cache_layer(layer, z)
+    return LOW_ZOOM_PWS_CACHE_LAYER if layer == "pws" && z < PWS_MIN_ZOOM
+
+    layer
+  end
 end

--- a/app/services/tile_generator.rb
+++ b/app/services/tile_generator.rb
@@ -5,6 +5,21 @@ module TileGenerator
   PWS_MIN_ZOOM = 5
   PLACES_MIN_ZOOM = 8
   LOW_ZOOM_PWS_CACHE_LAYER = "pws_low_poly_v1"
+  PWS_GENERALIZATION_PROFILES = [
+    {zoom_range: 0..4, column: "geom_z0_4", tolerance: 0.05},
+    {zoom_range: 5..5, column: "geom_z5", tolerance: 0.01},
+    {zoom_range: 6..6, column: "geom_z6", tolerance: 0.005},
+    {zoom_range: 7..7, column: "geom_z7", tolerance: 0.001}
+  ].freeze
+  GENERALIZED_GEOMETRY_ASSIGNMENTS_ON_GEOM_SQL = PWS_GENERALIZATION_PROFILES.map { |profile|
+    "#{profile[:column]} = ST_Multi(ST_SimplifyPreserveTopology(geom, #{profile[:tolerance]}))"
+  }.join(",\n          ").freeze
+  GENERALIZED_GEOMETRY_ASSIGNMENTS_ON_SAG_GEOM_SQL = PWS_GENERALIZATION_PROFILES.map { |profile|
+    "#{profile[:column]} = ST_Multi(ST_SimplifyPreserveTopology(sag.geom, #{profile[:tolerance]}))"
+  }.join(",\n            ").freeze
+  GENERALIZED_GEOMETRY_MISSING_SQL = PWS_GENERALIZATION_PROFILES.map { |profile|
+    "#{profile[:column]} IS NULL"
+  }.join("\n                OR ").freeze
 
   # Simplification tolerances keyed by max zoom level.
   SIMPLIFICATION = [
@@ -82,12 +97,16 @@ module TileGenerator
   # --- private below this line (module_function makes all methods public,
   #     so we rely on convention — callers should use the API above) ---
 
-  def generate_layer(layer, z, x, y, simp)
+  def generate_layer!(layer, z, x, y, simp)
     sql = layer_sql(layer, z, x, y, simp)
     return "".b if sql.nil?
 
     rows = ApplicationRecord.connection.execute(sql)
     rows.first&.dig("mvt").then { |raw| raw ? PG::Connection.unescape_bytea(raw) : "".b }
+  end
+
+  def generate_layer(layer, z, x, y, simp)
+    generate_layer!(layer, z, x, y, simp)
   rescue ActiveRecord::StatementInvalid => e
     Rails.logger.warn("[TileGenerator] SQL error for #{layer}/#{z}/#{x}/#{y}: #{e.message}")
     "".b
@@ -198,17 +217,16 @@ module TileGenerator
   end
 
   def pws_geometry_sql(z, simp)
-    column = case z
-    when 0..4 then "geom_z0_4"
-    when 5 then "geom_z5"
-    when 6 then "geom_z6"
-    when 7 then "geom_z7"
-    end
+    column = generalized_geometry_profile_for_zoom(z)&.fetch(:column)
     fallback = "ST_SimplifyPreserveTopology(sag.geom, #{simp})"
 
     column ? "COALESCE(sag.#{column}, #{fallback})" : fallback
   end
   # rubocop:enable Metrics/MethodLength
+
+  def generalized_geometry_profile_for_zoom(z)
+    PWS_GENERALIZATION_PROFILES.find { |profile| profile[:zoom_range].cover?(z) }
+  end
 
   def cache_layer(layer, z)
     return LOW_ZOOM_PWS_CACHE_LAYER if layer == "pws" && z < PWS_MIN_ZOOM

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -143,9 +143,11 @@ else
     result = nil
     warm_ms = (Benchmark.realtime { result = TileGenerator.build_tile(z, x, y) } * 1000).round
     size_kb = (result.bytesize / 1024.0).round(1)
-    cached = TileCache.where(z: z, x: x, y: y).count
-    fully_cached = cached >= expected_layers.size
-    status = fully_cached ? "warm" : "partial (#{cached}/#{expected_layers.size} expected layers cached)"
+    cached_layers = TileCache.where(z: z, x: x, y: y).pluck(:layer)
+    expected_cache_layers = TileBenchmark.expected_cache_layers(z)
+    cached = (expected_cache_layers & cached_layers).size
+    fully_cached = (expected_cache_layers - cached_layers).empty?
+    status = fully_cached ? "warm" : "partial (#{cached}/#{expected_cache_layers.size} expected cache layers present)"
     tee(output, format("  %-52s %6dms  (%s KB)  [%s; %s: %s]", "tile z=#{z} x=#{x} y=#{y}", warm_ms, size_kb, tier, status, expected_layers.join(",")))
   end
 end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -46,8 +46,8 @@ tee(output, "=" * 60)
 # Seed values — picked live from the DB so the script works on any dataset
 # ---------------------------------------------------------------------------
 sample_county_geoid = CartographicCounty.first&.geoid
-sample_place_geoid  = PlaceSystemCrosswalk.first&.geoid
-largest_state       = PublicWaterSystem.group(:stusps).count.max_by { |_, v| v }&.first
+sample_place_geoid = PlaceSystemCrosswalk.first&.geoid
+largest_state = PublicWaterSystem.group(:stusps).count.max_by { |_, v| v }&.first
 
 # ---------------------------------------------------------------------------
 # 1. Filter queries — mirrors apply_filters paths in HomeController/StatsController
@@ -121,10 +121,12 @@ measure(output, "first page, state filter (#{largest_state}), all associations")
 end
 
 # ---------------------------------------------------------------------------
-# 5. Tile generation — warm cache retrieval (TilesController#show path)
-#    Measures cache hit speed only. Run bin/benchmark-cold for cold timings.
+# 5. Tile generation — zoom-tier cache retrieval (TilesController#show path)
+#    Measures cache hit speed only. Run bin/benchmark-tiles for the safe
+#    cold-SQL regression guard or bin/benchmark-cold for destructive cold-cache
+#    investigations.
 # ---------------------------------------------------------------------------
-section(output, "5. Tile generation (warm cache)")
+section(output, "5. Tile generation (warm cache by zoom tier)")
 
 cached_count = TileCache.count
 if cached_count == 0
@@ -132,13 +134,19 @@ if cached_count == 0
   tee(output, "    bin/rails runner \"TileCacheWarmJob.perform_now\"")
 else
   tee(output, "  #{cached_count} cached tiles found")
-  [[2, 0, 1], [5, 9, 12], [8, 59, 95]].each do |z, x, y|
+  TileBenchmark::DEFAULT_SAMPLES.each do |sample|
+    z = sample.z
+    x = sample.x
+    y = sample.y
+    expected_layers = TileBenchmark.expected_layers(z)
+    tier = TileBenchmark.budget_for(z).tier
     result = nil
     warm_ms = (Benchmark.realtime { result = TileGenerator.build_tile(z, x, y) } * 1000).round
     size_kb = (result.bytesize / 1024.0).round(1)
     cached = TileCache.where(z: z, x: x, y: y).count
-    status = cached == TileGenerator.layers.size ? "warm" : "partial (#{cached}/#{TileGenerator.layers.size} layers cached)"
-    tee(output, format("  %-52s %6dms  (%s KB)  [%s]", "tile z=#{z} x=#{x} y=#{y}", warm_ms, size_kb, status))
+    fully_cached = cached >= expected_layers.size
+    status = fully_cached ? "warm" : "partial (#{cached}/#{expected_layers.size} expected layers cached)"
+    tee(output, format("  %-52s %6dms  (%s KB)  [%s; %s: %s]", "tile z=#{z} x=#{x} y=#{y}", warm_ms, size_kb, tier, status, expected_layers.join(",")))
   end
 end
 

--- a/bin/benchmark-cold
+++ b/bin/benchmark-cold
@@ -7,8 +7,8 @@
 #
 #   bin/rails runner "TileCacheWarmJob.perform_now"
 #
-# Use bin/benchmark (no suffix) for routine regression testing — it never
-# touches the cache.
+# Use bin/benchmark-tiles for routine tile regression testing — it never
+# touches the cache. Use bin/benchmark for broad query benchmarking.
 
 require "benchmark"
 require "fileutils"
@@ -45,15 +45,26 @@ TileCache.delete_all
 tee(output, "\n  Tile cache cleared (#{TileCache.count} tiles remaining)")
 
 tee(output, "\n#{SEPARATOR}")
-tee(output, "  Tile generation (cold → warm)")
+tee(output, "  Tile generation (cold -> warm)")
 tee(output, SEPARATOR)
 
-[[2, 0, 1], [5, 9, 12], [8, 59, 95]].each do |z, x, y|
+TileBenchmark::DEFAULT_SAMPLES.each do |sample|
+  z = sample.z
+  x = sample.x
+  y = sample.y
+  expected_layers = TileBenchmark.expected_layers(z)
+  tier = TileBenchmark.budget_for(z).tier
   result = nil
   cold_ms = (Benchmark.realtime { result = TileGenerator.build_tile(z, x, y) } * 1000).round
   warm_ms = (Benchmark.realtime { TileGenerator.build_tile(z, x, y) } * 1000).round
   size_kb = (result.bytesize / 1024.0).round(1)
-  tee(output, format("  %-52s cold: %4dms  warm: %4dms  (%s KB)", "tile z=#{z} x=#{x} y=#{y}", cold_ms, warm_ms, size_kb))
+  tee(output, format("  %-52s %-16s cold: %4dms  warm: %4dms  %7.1f KB  layers: %s",
+    "tile z=#{z} x=#{x} y=#{y}",
+    "(#{tier})",
+    cold_ms,
+    warm_ms,
+    size_kb,
+    expected_layers.join(",")))
 end
 
 tee(output, "\n#{SEPARATOR}")

--- a/bin/benchmark-tiles
+++ b/bin/benchmark-tiles
@@ -2,7 +2,7 @@
 # Safe local tile performance guard.
 # Run with: bin/rails runner bin/benchmark-tiles
 #
-# Cold samples call TileGenerator.generate_layer directly, so they do not read,
+# Cold samples call TileGenerator.generate_layer! directly, so they do not read,
 # clear, or mutate tile_cache. Warm samples call TileGenerator.build_tile only
 # when every expected layer for that z/x/y is already cached.
 

--- a/bin/benchmark-tiles
+++ b/bin/benchmark-tiles
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# Safe local tile performance guard.
+# Run with: bin/rails runner bin/benchmark-tiles
+#
+# Cold samples call TileGenerator.generate_layer directly, so they do not read,
+# clear, or mutate tile_cache. Warm samples call TileGenerator.build_tile only
+# when every expected layer for that z/x/y is already cached.
+
+report = TileBenchmark::Runner.new(connection: ApplicationRecord.connection).run
+exit report.exit_status

--- a/db/migrate/20260630000001_add_generalized_geometries_to_service_area_geometries.rb
+++ b/db/migrate/20260630000001_add_generalized_geometries_to_service_area_geometries.rb
@@ -8,10 +8,5 @@ class AddGeneralizedGeometriesToServiceAreaGeometries < ActiveRecord::Migration[
       geographic: false, srid: 4326, limit: {type: :multi_polygon}
     add_column :service_area_geometries, :geom_z7, :geometry,
       geographic: false, srid: 4326, limit: {type: :multi_polygon}
-
-    add_index :service_area_geometries, :geom_z0_4, using: :gist
-    add_index :service_area_geometries, :geom_z5, using: :gist
-    add_index :service_area_geometries, :geom_z6, using: :gist
-    add_index :service_area_geometries, :geom_z7, using: :gist
   end
 end

--- a/db/migrate/20260630000001_add_generalized_geometries_to_service_area_geometries.rb
+++ b/db/migrate/20260630000001_add_generalized_geometries_to_service_area_geometries.rb
@@ -1,0 +1,17 @@
+class AddGeneralizedGeometriesToServiceAreaGeometries < ActiveRecord::Migration[8.1]
+  def change
+    add_column :service_area_geometries, :geom_z0_4, :geometry,
+      geographic: false, srid: 4326, limit: {type: :multi_polygon}
+    add_column :service_area_geometries, :geom_z5, :geometry,
+      geographic: false, srid: 4326, limit: {type: :multi_polygon}
+    add_column :service_area_geometries, :geom_z6, :geometry,
+      geographic: false, srid: 4326, limit: {type: :multi_polygon}
+    add_column :service_area_geometries, :geom_z7, :geometry,
+      geographic: false, srid: 4326, limit: {type: :multi_polygon}
+
+    add_index :service_area_geometries, :geom_z0_4, using: :gist
+    add_index :service_area_geometries, :geom_z5, using: :gist
+    add_index :service_area_geometries, :geom_z6, using: :gist
+    add_index :service_area_geometries, :geom_z7, using: :gist
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_16_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -188,11 +188,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_000001) do
     t.datetime "created_at", null: false
     t.geometry "geom", limit: {srid: 4326, type: "multi_polygon"}
     t.string "geom_digest"
+    t.geometry "geom_z0_4", limit: {srid: 4326, type: "multi_polygon"}
+    t.geometry "geom_z5", limit: {srid: 4326, type: "multi_polygon"}
+    t.geometry "geom_z6", limit: {srid: 4326, type: "multi_polygon"}
+    t.geometry "geom_z7", limit: {srid: 4326, type: "multi_polygon"}
     t.string "pwsid", null: false
     t.datetime "updated_at", null: false
     t.index ["centroid"], name: "index_service_area_geometries_on_centroid", using: :gist
     t.index ["geom"], name: "index_service_area_geometries_on_geom", using: :gist
     t.index ["geom_digest"], name: "index_service_area_geometries_on_geom_digest"
+    t.index ["geom_z0_4"], name: "index_service_area_geometries_on_geom_z0_4", using: :gist
+    t.index ["geom_z5"], name: "index_service_area_geometries_on_geom_z5", using: :gist
+    t.index ["geom_z6"], name: "index_service_area_geometries_on_geom_z6", using: :gist
+    t.index ["geom_z7"], name: "index_service_area_geometries_on_geom_z7", using: :gist
     t.index ["pwsid"], name: "index_service_area_geometries_on_pwsid", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,10 +197,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_000001) do
     t.index ["centroid"], name: "index_service_area_geometries_on_centroid", using: :gist
     t.index ["geom"], name: "index_service_area_geometries_on_geom", using: :gist
     t.index ["geom_digest"], name: "index_service_area_geometries_on_geom_digest"
-    t.index ["geom_z0_4"], name: "index_service_area_geometries_on_geom_z0_4", using: :gist
-    t.index ["geom_z5"], name: "index_service_area_geometries_on_geom_z5", using: :gist
-    t.index ["geom_z6"], name: "index_service_area_geometries_on_geom_z6", using: :gist
-    t.index ["geom_z7"], name: "index_service_area_geometries_on_geom_z7", using: :gist
     t.index ["pwsid"], name: "index_service_area_geometries_on_pwsid", unique: true
   end
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -119,6 +119,14 @@ Use **Actions → Refresh Cartographic Boundaries → Run workflow** to reload t
 
 The job summary shows the task ARNs, environment, and the row counts from the verification step.
 
+This workflow does not backfill PWS generalized geometries. Those columns live on `service_area_geometries` and are derived from EPA SABS service-area polygons, not from TIGER cartographic boundaries.
+
+### PWS generalized geometries
+
+Production backfills missing `service_area_geometries.geom_z0_4`, `geom_z5`, `geom_z6`, and `geom_z7` during the scheduled nightly ETL. This runs even when all source files are unchanged, because the ETL post-import step checks for missing generalized geometry columns before returning from a no-op import.
+
+Page requests do not populate these columns. Normal geometry imports keep them current after the initial deploy, and a forced `epa_sabs_geoms` import also repopulates them, but neither is required just to complete the rollout. The `etl:geometries:generalize` rake task exists for local development or an explicit manual fallback.
+
 ### Sweep stale PR environments
 
 Use **Actions → Teardown Stale PR Environments → Run workflow** to bulk-destroy all PR environments whose last commit is older than a threshold. Requires `pr-teardowns` environment approval.

--- a/lib/tasks/etl.rake
+++ b/lib/tasks/etl.rake
@@ -21,4 +21,20 @@ namespace :etl do
       puts "ETL import complete."
     end
   end
+
+  namespace :geometries do
+    desc <<~DESC
+      Backfill precomputed low-zoom service-area geometries.
+
+      Usage:
+        bin/rails etl:geometries:generalize
+        PWSIDS=CA0000001,VT0000001 bin/rails etl:geometries:generalize
+    DESC
+    task generalize: :environment do
+      pwsids = ENV.fetch("PWSIDS", "").split(",").map(&:strip).reject(&:blank?)
+      Etl::PostImportSteps.generate_generalized_geometries(pwsids: pwsids.presence)
+      Etl::PostImportSteps.analyze_spatial_tables
+      puts "Generalized service-area geometries backfilled."
+    end
+  end
 end

--- a/spec/factories/service_area_geometries.rb
+++ b/spec/factories/service_area_geometries.rb
@@ -6,6 +6,10 @@
 #  centroid    :geometry         point, 4326
 #  geom        :geometry         multipolygon, 4326
 #  geom_digest :string
+#  geom_z0_4   :geometry         multipolygon, 4326
+#  geom_z5     :geometry         multipolygon, 4326
+#  geom_z6     :geometry         multipolygon, 4326
+#  geom_z7     :geometry         multipolygon, 4326
 #  pwsid       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -15,6 +19,10 @@
 #  index_service_area_geometries_on_centroid     (centroid) USING gist
 #  index_service_area_geometries_on_geom         (geom) USING gist
 #  index_service_area_geometries_on_geom_digest  (geom_digest)
+#  index_service_area_geometries_on_geom_z0_4    (geom_z0_4) USING gist
+#  index_service_area_geometries_on_geom_z5      (geom_z5) USING gist
+#  index_service_area_geometries_on_geom_z6      (geom_z6) USING gist
+#  index_service_area_geometries_on_geom_z7      (geom_z7) USING gist
 #  index_service_area_geometries_on_pwsid        (pwsid) UNIQUE
 #
 FactoryBot.define do

--- a/spec/factories/service_area_geometries.rb
+++ b/spec/factories/service_area_geometries.rb
@@ -19,10 +19,6 @@
 #  index_service_area_geometries_on_centroid     (centroid) USING gist
 #  index_service_area_geometries_on_geom         (geom) USING gist
 #  index_service_area_geometries_on_geom_digest  (geom_digest)
-#  index_service_area_geometries_on_geom_z0_4    (geom_z0_4) USING gist
-#  index_service_area_geometries_on_geom_z5      (geom_z5) USING gist
-#  index_service_area_geometries_on_geom_z6      (geom_z6) USING gist
-#  index_service_area_geometries_on_geom_z7      (geom_z7) USING gist
 #  index_service_area_geometries_on_pwsid        (pwsid) UNIQUE
 #
 FactoryBot.define do

--- a/spec/jobs/tile_cache_warm_job_spec.rb
+++ b/spec/jobs/tile_cache_warm_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TileCacheWarmJob, type: :job do
       expect(call_count).to be > 0
     end
 
-    it "warms public water system tiles for low-zoom overview tiles" do
+    it "warms public water system polygon tiles for low-zoom overview tiles" do
       allow_any_instance_of(described_class).to receive(:tile_coordinates).and_return([[0, 0]])
 
       described_class.perform_now

--- a/spec/models/service_area_geometry_spec.rb
+++ b/spec/models/service_area_geometry_spec.rb
@@ -6,6 +6,10 @@
 #  centroid    :geometry         point, 4326
 #  geom        :geometry         multipolygon, 4326
 #  geom_digest :string
+#  geom_z0_4   :geometry         multipolygon, 4326
+#  geom_z5     :geometry         multipolygon, 4326
+#  geom_z6     :geometry         multipolygon, 4326
+#  geom_z7     :geometry         multipolygon, 4326
 #  pwsid       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -15,6 +19,10 @@
 #  index_service_area_geometries_on_centroid     (centroid) USING gist
 #  index_service_area_geometries_on_geom         (geom) USING gist
 #  index_service_area_geometries_on_geom_digest  (geom_digest)
+#  index_service_area_geometries_on_geom_z0_4    (geom_z0_4) USING gist
+#  index_service_area_geometries_on_geom_z5      (geom_z5) USING gist
+#  index_service_area_geometries_on_geom_z6      (geom_z6) USING gist
+#  index_service_area_geometries_on_geom_z7      (geom_z7) USING gist
 #  index_service_area_geometries_on_pwsid        (pwsid) UNIQUE
 #
 require "rails_helper"

--- a/spec/services/etl/post_import_steps_spec.rb
+++ b/spec/services/etl/post_import_steps_spec.rb
@@ -68,6 +68,63 @@ RSpec.describe Etl::PostImportSteps do
     end
   end
 
+  describe ".generate_generalized_geometries" do
+    before do
+      create(:public_water_system, pwsid: "VT0000002")
+      insert_geometry("VT0000002", VERMONT_WKT)
+    end
+
+    it "populates all low-zoom generalized geometry columns" do
+      described_class.generate_generalized_geometries
+
+      row = conn.select_one(<<~SQL)
+        SELECT
+          geom_z0_4 IS NOT NULL AS geom_z0_4_present,
+          geom_z5 IS NOT NULL AS geom_z5_present,
+          geom_z6 IS NOT NULL AS geom_z6_present,
+          geom_z7 IS NOT NULL AS geom_z7_present
+        FROM service_area_geometries
+        WHERE pwsid = 'VT0000001'
+      SQL
+
+      expect(row).to include(
+        "geom_z0_4_present" => true,
+        "geom_z5_present" => true,
+        "geom_z6_present" => true,
+        "geom_z7_present" => true
+      )
+    end
+
+    it "can scope updates to selected pwsids" do
+      described_class.generate_generalized_geometries(pwsids: ["VT0000001"])
+
+      scoped = conn.select_one("SELECT geom_z5 IS NOT NULL AS present FROM service_area_geometries WHERE pwsid = 'VT0000001'")
+      unscoped = conn.select_one("SELECT geom_z5 IS NOT NULL AS present FROM service_area_geometries WHERE pwsid = 'VT0000002'")
+
+      expect(scoped["present"]).to be(true)
+      expect(unscoped["present"]).to be(false)
+    end
+  end
+
+  describe ".backfill_missing_generalized_geometries" do
+    before do
+      create(:public_water_system, pwsid: "VT0000002")
+      insert_geometry("VT0000002", VERMONT_WKT)
+      described_class.generate_generalized_geometries(pwsids: ["VT0000002"])
+    end
+
+    it "populates only rows missing generalized geometry columns" do
+      already_present_updated_at = ServiceAreaGeometry.find_by!(pwsid: "VT0000002").updated_at
+
+      described_class.backfill_missing_generalized_geometries
+
+      missing_row = conn.select_one("SELECT geom_z7 IS NOT NULL AS present FROM service_area_geometries WHERE pwsid = 'VT0000001'")
+
+      expect(missing_row["present"]).to be(true)
+      expect(ServiceAreaGeometry.find_by!(pwsid: "VT0000002").updated_at).to eq(already_present_updated_at)
+    end
+  end
+
   describe ".assign_state_codes" do
     before do
       insert_state("VT", VERMONT_STATE_WKT)
@@ -149,6 +206,12 @@ RSpec.describe Etl::PostImportSteps do
       described_class.call(imported_files: [])
     end
 
+    it "backfills missing generalized geometries when scheduled ETL has no imported files" do
+      expect(described_class).to receive(:backfill_missing_generalized_geometries)
+
+      described_class.call(import_results: [])
+    end
+
     it "raises when normal ETL omits import result metadata" do
       expect { described_class.call }.to raise_error(ArgumentError, /import_results/)
     end
@@ -217,7 +280,9 @@ RSpec.describe Etl::PostImportSteps do
       calls = []
 
       allow(described_class).to receive(:fix_invalid_geometries) { |pwsids: nil| calls << [:fix_invalid_geometries, pwsids] }
+      allow(described_class).to receive(:backfill_missing_generalized_geometries) { calls << [:backfill_missing_generalized_geometries, nil] }
       allow(described_class).to receive(:generate_centroids) { |pwsids: nil| calls << [:generate_centroids, pwsids] }
+      allow(described_class).to receive(:generate_generalized_geometries) { |pwsids: nil| calls << [:generate_generalized_geometries, pwsids] }
       allow(CartographicBoundaries).to receive(:load) { calls << [:load_boundaries, nil] }
       allow(described_class).to receive(:assign_state_codes) { |pwsids: nil| calls << [:assign_state_codes, pwsids] }
       allow(described_class).to receive(:analyze_spatial_tables) { calls << [:analyze_spatial_tables, nil] }
@@ -232,8 +297,10 @@ RSpec.describe Etl::PostImportSteps do
       described_class.call(import_results: [result])
 
       expect(calls).to eq([
+        [:backfill_missing_generalized_geometries, nil],
         [:fix_invalid_geometries, ["VT0000001"]],
         [:generate_centroids, ["VT0000001"]],
+        [:generate_generalized_geometries, ["VT0000001"]],
         [:load_boundaries, nil],
         [:assign_state_codes, ["VT0000001"]],
         [:analyze_spatial_tables, nil],
@@ -251,6 +318,7 @@ RSpec.describe Etl::PostImportSteps do
       )
       allow(described_class).to receive(:fix_invalid_geometries)
       allow(described_class).to receive(:generate_centroids)
+      allow(described_class).to receive(:generate_generalized_geometries)
       allow(CartographicBoundaries).to receive(:load)
       allow(described_class).to receive(:assign_state_codes)
       allow(described_class).to receive(:analyze_spatial_tables)
@@ -283,6 +351,7 @@ RSpec.describe Etl::PostImportSteps do
 
       allow(described_class).to receive(:fix_invalid_geometries)
       allow(described_class).to receive(:generate_centroids)
+      allow(described_class).to receive(:generate_generalized_geometries)
       allow(described_class).to receive(:assign_state_codes)
       allow(described_class).to receive(:analyze_spatial_tables)
       allow(described_class).to receive(:build_place_crosswalks).and_return([])
@@ -305,6 +374,7 @@ RSpec.describe Etl::PostImportSteps do
 
       allow(described_class).to receive(:fix_invalid_geometries)
       allow(described_class).to receive(:generate_centroids)
+      allow(described_class).to receive(:generate_generalized_geometries)
       allow(described_class).to receive(:assign_state_codes)
       allow(described_class).to receive(:analyze_spatial_tables)
       allow(described_class).to receive(:build_place_crosswalks).and_return([])
@@ -321,6 +391,7 @@ RSpec.describe Etl::PostImportSteps do
 
       allow(described_class).to receive(:fix_invalid_geometries) { calls << :fix_invalid_geometries }
       allow(described_class).to receive(:generate_centroids) { calls << :generate_centroids }
+      allow(described_class).to receive(:generate_generalized_geometries) { calls << :generate_generalized_geometries }
       allow(CartographicBoundaries).to receive(:load) { calls << :load_boundaries }
       allow(described_class).to receive(:assign_state_codes) { calls << :assign_state_codes }
       allow(described_class).to receive(:rebuild_spatial_indexes) { calls << :rebuild_spatial_indexes }
@@ -333,6 +404,7 @@ RSpec.describe Etl::PostImportSteps do
       expect(calls).to eq([
         :fix_invalid_geometries,
         :generate_centroids,
+        :generate_generalized_geometries,
         :load_boundaries,
         :assign_state_codes,
         :rebuild_spatial_indexes,

--- a/spec/services/tile_benchmark_spec.rb
+++ b/spec/services/tile_benchmark_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe TileBenchmark do
     end
   end
 
+  describe ".expected_cache_layers" do
+    it "uses the tile generator cache key mapping for each layer" do
+      allow(TileGenerator).to receive(:layers_for_zoom).with(3).and_return(%w[pws states])
+
+      expect(described_class.expected_cache_layers(3)).to eq(%w[pws_low_poly_v1 states])
+    end
+  end
+
   describe TileBenchmark::Runner do
     let(:sample) { TileBenchmark::Sample.new(z: 5, x: 9, y: 12) }
     let(:output) { StringIO.new }
@@ -57,12 +65,18 @@ RSpec.describe TileBenchmark do
           0.01
         end
 
-        def self.generate_layer(_layer, _z, _x, _y, _simp)
+        def self.generate_layer!(_layer, _z, _x, _y, _simp)
           "mvt".b
         end
 
         def self.build_tile(_z, _x, _y)
           "mvt".b
+        end
+
+        def self.cache_layer(layer, z)
+          return "pws_low_poly_v1" if layer == "pws" && z < 5
+
+          layer
         end
       end
     end
@@ -72,7 +86,7 @@ RSpec.describe TileBenchmark do
         samples: [sample],
         output: output,
         tile_generator: tile_generator,
-        cache_model: class_double(TileCache, where: double(count: 0)),
+        cache_model: class_double(TileCache, where: double(pluck: [])),
         clock: fake_clock(0.0, 7.5),
         env: {"TILE_BENCH_FAIL_MS_Z5_7" => "6000"}
       )
@@ -86,7 +100,7 @@ RSpec.describe TileBenchmark do
 
     it "marks timeout failures distinctly from slow completed samples" do
       timeout_generator = Class.new(tile_generator) do
-        def self.generate_layer(_layer, _z, _x, _y, _simp)
+        def self.generate_layer!(_layer, _z, _x, _y, _simp)
           raise Timeout::Error
         end
       end
@@ -95,7 +109,7 @@ RSpec.describe TileBenchmark do
         samples: [sample],
         output: output,
         tile_generator: timeout_generator,
-        cache_model: class_double(TileCache, where: double(count: 0)),
+        cache_model: class_double(TileCache, where: double(pluck: [])),
         clock: fake_clock(0.0, 6.0),
         env: {}
       )
@@ -112,7 +126,7 @@ RSpec.describe TileBenchmark do
         samples: [sample],
         output: output,
         tile_generator: tile_generator,
-        cache_model: class_double(TileCache, where: double(count: 0)),
+        cache_model: class_double(TileCache, where: double(pluck: [])),
         clock: fake_clock(0.0, 8.0),
         env: {"TILE_BENCH_DB_TIMEOUT_MS_Z5_7" => "8000"}
       )
@@ -124,9 +138,32 @@ RSpec.describe TileBenchmark do
       expect(report.results.first.timeout?).to be(true)
     end
 
+    it "marks SQL errors as failures instead of treating them as empty tiles" do
+      sql_error_generator = Class.new(tile_generator) do
+        def self.generate_layer!(_layer, _z, _x, _y, _simp)
+          raise ActiveRecord::StatementInvalid, "bad sql"
+        end
+      end
+
+      runner = described_class.new(
+        samples: [sample],
+        output: output,
+        tile_generator: sql_error_generator,
+        cache_model: class_double(TileCache, where: double(pluck: [])),
+        clock: fake_clock(0.0, 0.1),
+        env: {}
+      )
+
+      report = runner.run
+
+      expect(report.exit_status).to eq(1)
+      expect(report.results.first.status).to eq(:error)
+      expect(report.results.first.message).to include("sql error")
+    end
+
     it "uses TileGenerator.layers_for_zoom for expected warm cache layer counts" do
-      relation = double(count: 3)
-      expect(tile_generator).to receive(:layers_for_zoom).with(5).and_call_original
+      relation = double(pluck: %w[pws counties states])
+      expect(tile_generator).to receive(:layers_for_zoom).with(5).twice.and_call_original
       expect(tile_generator).to receive(:build_tile).with(5, 9, 12).and_return("warm".b)
 
       runner = described_class.new(
@@ -141,6 +178,26 @@ RSpec.describe TileBenchmark do
       report = runner.run
 
       expect(report.results.map(&:mode)).to include(:warm)
+    end
+
+    it "skips warm timing when only stale low-zoom cache keys exist" do
+      low_zoom_sample = TileBenchmark::Sample.new(z: 3, x: 1, y: 2)
+      relation = double(pluck: %w[pws states])
+
+      expect(tile_generator).not_to receive(:build_tile)
+
+      runner = described_class.new(
+        samples: [low_zoom_sample],
+        output: output,
+        tile_generator: tile_generator,
+        cache_model: class_double(TileCache, where: relation),
+        clock: fake_clock(0.0, 0.1),
+        env: {}
+      )
+
+      report = runner.run
+
+      expect(report.results.map(&:mode)).not_to include(:warm)
     end
 
     def fake_clock(*values)

--- a/spec/services/tile_benchmark_spec.rb
+++ b/spec/services/tile_benchmark_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe TileBenchmark do
+  describe ".budget_for" do
+    it "uses the overview tier for z0-z4" do
+      [0, 4].each do |z|
+        budget = described_class.budget_for(z, env: {})
+
+        expect(budget.tier).to eq("overview")
+        expect(budget.warn_ms).to eq(3000)
+        expect(budget.fail_ms).to eq(8000)
+        expect(budget.db_timeout_ms).to eq(10_000)
+      end
+    end
+
+    it "uses the state-selection tier for z5-z7" do
+      [5, 7].each do |z|
+        budget = described_class.budget_for(z, env: {})
+
+        expect(budget.tier).to eq("state selection")
+        expect(budget.warn_ms).to eq(2000)
+        expect(budget.fail_ms).to eq(6000)
+        expect(budget.db_timeout_ms).to eq(8000)
+      end
+    end
+
+    it "uses the system-browsing tier for z8 and above" do
+      [8, 12].each do |z|
+        budget = described_class.budget_for(z, env: {})
+
+        expect(budget.tier).to eq("system browsing")
+        expect(budget.warn_ms).to eq(1000)
+        expect(budget.fail_ms).to eq(4000)
+        expect(budget.db_timeout_ms).to eq(6000)
+      end
+    end
+  end
+
+  describe ".expected_layers" do
+    it "delegates expected layer counts to TileGenerator.layers_for_zoom" do
+      allow(TileGenerator).to receive(:layers_for_zoom).with(7).and_return(%w[pws counties states])
+
+      expect(described_class.expected_layers(7)).to eq(%w[pws counties states])
+    end
+  end
+
+  describe TileBenchmark::Runner do
+    let(:sample) { TileBenchmark::Sample.new(z: 5, x: 9, y: 12) }
+    let(:output) { StringIO.new }
+    let(:tile_generator) do
+      Class.new do
+        def self.layers_for_zoom(_z)
+          %w[pws counties states]
+        end
+
+        def self.layer_simplification_tolerance(_layer, _z)
+          0.01
+        end
+
+        def self.generate_layer(_layer, _z, _x, _y, _simp)
+          "mvt".b
+        end
+
+        def self.build_tile(_z, _x, _y)
+          "mvt".b
+        end
+      end
+    end
+
+    it "exits nonzero when a completed sample exceeds the fail budget" do
+      runner = described_class.new(
+        samples: [sample],
+        output: output,
+        tile_generator: tile_generator,
+        cache_model: class_double(TileCache, where: double(count: 0)),
+        clock: fake_clock(0.0, 7.5),
+        env: {"TILE_BENCH_FAIL_MS_Z5_7" => "6000"}
+      )
+
+      report = runner.run
+
+      expect(report.exit_status).to eq(1)
+      expect(report.results.first.status).to eq(:fail)
+      expect(report.results.first.timeout?).to be(false)
+    end
+
+    it "marks timeout failures distinctly from slow completed samples" do
+      timeout_generator = Class.new(tile_generator) do
+        def self.generate_layer(_layer, _z, _x, _y, _simp)
+          raise Timeout::Error
+        end
+      end
+
+      runner = described_class.new(
+        samples: [sample],
+        output: output,
+        tile_generator: timeout_generator,
+        cache_model: class_double(TileCache, where: double(count: 0)),
+        clock: fake_clock(0.0, 6.0),
+        env: {}
+      )
+
+      report = runner.run
+
+      expect(report.exit_status).to eq(1)
+      expect(report.results.first.status).to eq(:timeout)
+      expect(report.results.first.timeout?).to be(true)
+    end
+
+    it "marks samples that run through the database timeout as timeout failures" do
+      runner = described_class.new(
+        samples: [sample],
+        output: output,
+        tile_generator: tile_generator,
+        cache_model: class_double(TileCache, where: double(count: 0)),
+        clock: fake_clock(0.0, 8.0),
+        env: {"TILE_BENCH_DB_TIMEOUT_MS_Z5_7" => "8000"}
+      )
+
+      report = runner.run
+
+      expect(report.exit_status).to eq(1)
+      expect(report.results.first.status).to eq(:timeout)
+      expect(report.results.first.timeout?).to be(true)
+    end
+
+    it "uses TileGenerator.layers_for_zoom for expected warm cache layer counts" do
+      relation = double(count: 3)
+      expect(tile_generator).to receive(:layers_for_zoom).with(5).and_call_original
+      expect(tile_generator).to receive(:build_tile).with(5, 9, 12).and_return("warm".b)
+
+      runner = described_class.new(
+        samples: [sample],
+        output: output,
+        tile_generator: tile_generator,
+        cache_model: class_double(TileCache, where: relation),
+        clock: fake_clock(0.0, 0.1, 0.1, 0.2),
+        env: {}
+      )
+
+      report = runner.run
+
+      expect(report.results.map(&:mode)).to include(:warm)
+    end
+
+    def fake_clock(*values)
+      Class.new do
+        define_singleton_method(:values) { @values ||= values.dup }
+        define_singleton_method(:monotonic) { self.values.shift }
+      end
+    end
+  end
+end

--- a/spec/services/tile_generator_spec.rb
+++ b/spec/services/tile_generator_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe TileGenerator do
   end
 
   describe ".layer_simplification_tolerance" do
-    it "keeps public water systems visible at the national zoom-in boundary" do
-      expect(described_class.layer_simplification_tolerance("pws", 4)).to eq(0.01)
+    it "uses stronger simplification for low-zoom public water system polygons" do
+      expect(described_class.layer_simplification_tolerance("pws", 4)).to eq(0.05)
+      expect(described_class.layer_simplification_tolerance("pws", 5)).to eq(0.01)
     end
 
     it "keeps coarse simplification for low-zoom boundary layers" do
@@ -38,7 +39,8 @@ RSpec.describe TileGenerator do
   end
 
   describe ".layers_for_zoom" do
-    it "includes service areas before state selection is available" do
+    it "includes service area polygons before state selection zooms" do
+      expect(described_class.layers_for_zoom(0)).to eq(%w[pws states])
       expect(described_class.layers_for_zoom(4)).to eq(%w[pws states])
     end
 
@@ -132,6 +134,18 @@ RSpec.describe TileGenerator do
         expect(TileCache.where(layer: "states", z: 5, x: 16, y: 12)).to exist
       end
     end
+
+    it "does not reuse stale unversioned low-zoom public water system tiles" do
+      create(:tile_cache, layer: "pws", z: 3, x: 1, y: 2, mvt: "old".b)
+      allow(ApplicationRecord.connection).to receive(:execute)
+        .and_return([{"mvt" => PG::Connection.escape_bytea("new".b)}])
+
+      result = described_class.generate_tile("pws", 3, 1, 2)
+
+      expect(result).to eq("new".b)
+      expect(TileCache.where(layer: "pws", z: 3, x: 1, y: 2)).to exist
+      expect(TileCache.where(layer: "pws_low_poly_v1", z: 3, x: 1, y: 2)).to exist
+    end
   end
 
   describe ".layer_sql" do
@@ -150,6 +164,17 @@ RSpec.describe TileGenerator do
       expect(sql).to include("4096, 64, true")
       expect(sql).to include("sag.geom && ST_Transform(ST_TileEnvelope(5, 8, 12, margin => 64.0 / 4096), 4326)")
       expect(sql).to include("pws.area_sq_miles")
+    end
+
+    it "uses simplified polygons with reduced attributes for low-zoom public water systems" do
+      sql = described_class.layer_sql("pws", 3, 1, 2, 0.05)
+
+      expect(sql).to include("ST_Transform(ST_SimplifyPreserveTopology(sag.geom, 0.05), 3857)")
+      expect(sql).to include("sag.geom && ST_Transform(ST_TileEnvelope(3, 1, 2, margin => 64.0 / 4096), 4326)")
+      expect(sql).to include("pws.pwsid, pws.stusps")
+      expect(sql).not_to include("sag.centroid")
+      expect(sql).not_to include("pws.pws_name")
+      expect(sql).not_to include("pws.population_served_count")
     end
   end
 end

--- a/spec/services/tile_generator_spec.rb
+++ b/spec/services/tile_generator_spec.rb
@@ -169,12 +169,32 @@ RSpec.describe TileGenerator do
     it "uses simplified polygons with reduced attributes for low-zoom public water systems" do
       sql = described_class.layer_sql("pws", 3, 1, 2, 0.05)
 
-      expect(sql).to include("ST_Transform(ST_SimplifyPreserveTopology(sag.geom, 0.05), 3857)")
+      expect(sql).to include("ST_Transform(COALESCE(sag.geom_z0_4, ST_SimplifyPreserveTopology(sag.geom, 0.05)), 3857)")
       expect(sql).to include("sag.geom && ST_Transform(ST_TileEnvelope(3, 1, 2, margin => 64.0 / 4096), 4326)")
       expect(sql).to include("pws.pwsid, pws.stusps")
       expect(sql).not_to include("sag.centroid")
       expect(sql).not_to include("pws.pws_name")
       expect(sql).not_to include("pws.population_served_count")
+    end
+
+    it "uses the matching precomputed public water system geometry for zooms 0 through 7" do
+      expect(described_class.layer_sql("pws", 0, 0, 0, 0.05))
+        .to include("COALESCE(sag.geom_z0_4, ST_SimplifyPreserveTopology(sag.geom, 0.05))")
+      expect(described_class.layer_sql("pws", 4, 0, 0, 0.05))
+        .to include("COALESCE(sag.geom_z0_4, ST_SimplifyPreserveTopology(sag.geom, 0.05))")
+      expect(described_class.layer_sql("pws", 5, 8, 12, 0.01))
+        .to include("COALESCE(sag.geom_z5, ST_SimplifyPreserveTopology(sag.geom, 0.01))")
+      expect(described_class.layer_sql("pws", 6, 16, 24, 0.005))
+        .to include("COALESCE(sag.geom_z6, ST_SimplifyPreserveTopology(sag.geom, 0.005))")
+      expect(described_class.layer_sql("pws", 7, 32, 48, 0.001))
+        .to include("COALESCE(sag.geom_z7, ST_SimplifyPreserveTopology(sag.geom, 0.001))")
+    end
+
+    it "keeps public water system zoom 8 and above on raw geometry simplification" do
+      sql = described_class.layer_sql("pws", 8, 76, 93, 0.0005)
+
+      expect(sql).to include("ST_Transform(ST_SimplifyPreserveTopology(sag.geom, 0.0005), 3857)")
+      expect(sql).not_to include("geom_z")
     end
   end
 end

--- a/spec/services/tile_generator_spec.rb
+++ b/spec/services/tile_generator_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe TileGenerator do
           .to change { TileCache.where(layer: "pws", z: z, x: x, y: y).count }.from(0).to(1)
       end
     end
+
+    it "raises SQL errors to callers that need strict failure handling" do
+      allow(ApplicationRecord.connection).to receive(:execute)
+        .and_raise(ActiveRecord::StatementInvalid, "bad sql")
+
+      expect {
+        described_class.generate_layer!("pws", 5, 8, 12, 0.01)
+      }.to raise_error(ActiveRecord::StatementInvalid, /bad sql/)
+    end
   end
 
   describe ".build_tile" do
@@ -195,6 +204,15 @@ RSpec.describe TileGenerator do
 
       expect(sql).to include("ST_Transform(ST_SimplifyPreserveTopology(sag.geom, 0.0005), 3857)")
       expect(sql).not_to include("geom_z")
+    end
+
+    it "reuses the shared generalized geometry profile mapping for ETL update SQL" do
+      assignments = described_class::GENERALIZED_GEOMETRY_ASSIGNMENTS_ON_GEOM_SQL
+
+      expect(assignments).to include("geom_z0_4 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.05))")
+      expect(assignments).to include("geom_z5 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.01))")
+      expect(assignments).to include("geom_z6 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.005))")
+      expect(assignments).to include("geom_z7 = ST_Multi(ST_SimplifyPreserveTopology(geom, 0.001))")
     end
   end
 end


### PR DESCRIPTION
## Summary

Precomputes low-zoom service-area geometries and switches the national/state-selection tile path to use them, reducing the amount of geometry and attribute data pushed through overview tiles. It also adds a dedicated local tile performance guard so tile SQL, cache behavior, and rollout assumptions can be checked before merge.

## Changes

- Add precomputed generalized service-area geometry columns for z0-z7 and wire them into ETL post-import processing so nightly no-op ETLs backfill missing rows, geometry imports keep them current, and local operators have a targeted `etl:geometries:generalize` fallback.
- Switch low-zoom `pws` tiles to read from the generalized geometry columns (`COALESCE` falls back to runtime simplification until backfill finishes) and trim overview attributes down to the fields needed for state selection.
- Version the low-zoom `pws` cache key (`pws_low_poly_v1`) so new overview tiles cannot reuse stale high-detail cache rows while preserving the existing cache contract for z5+ tiles.
- Add `TileBenchmark` plus `bin/benchmark-tiles` as a non-destructive regression gate for overview, state-selection, and system-browsing samples (cold checks call `generate_layer!` so SQL failures surface as failures, not empty tiles).
- Tighten warm-cache benchmarking to verify the exact cache layers required for each zoom tier instead of counting any row at `z/x/y`, which avoids false warm hits when obsolete low-zoom cache rows are still present.
- Update the existing benchmark scripts and docs so local performance workflows clearly distinguish safe pre-merge checks from destructive cold-cache investigation.
- Cover the rollout with specs for generalized-geometry generation/backfill, versioned low-zoom cache behavior, and benchmark failure modes around timeouts, SQL errors, and stale cache keys.

## Notes for reviewers

- The migration adds generalized geometry columns but does not rely on page requests to populate them; rollout depends on ETL backfill or the explicit rake task.
- Low-zoom cache invalidation is intentionally one-way: overview `pws` tiles move to a new cache key rather than trying to rewrite old cache rows in place.
- The benchmark guard is meant to complement `bin/ci`, not replace it; it is focused on tile SQL and cache regressions rather than broad app correctness.

## Screenshots
<img width="678" height="425" alt="Screenshot 2026-06-30 at 8 08 52 AM" src="https://github.com/user-attachments/assets/f1e73be7-3157-4105-9c8d-64448421373e" />

