### PR TITLE
[Refactor] Address ETL Pipeline Feedback for Staging & Prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,20 @@ MAPBOX_STYLE_URL=mapbox://styles/your-account/your-style-id
 
 # ETL pipeline source URL — base HTTPS URL to the S3 folder containing the source data files.
 # Required for both local seeding (bin/rails db:seed) and the full ETL pipeline (bin/rails etl:import).
-# A single S3 bucket serves all environments (development, staging, production)
-ETL_SOURCE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/test-staged
+# Staging ECS should use .../staging; production ECS should use .../prod.
+ETL_SOURCE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging
+
+# Runtime environment identity. ECS services all run Rails in production mode,
+# so APP_ENV distinguishes staging, production, and preview behavior.
+APP_ENV=staging
+
+# Public download/documentation URLs rendered by the app.
+# Staging ECS should use .../public-data-downloads/staging; production ECS should use .../public-data-downloads/prod.
+PUBLIC_DOWNLOADS_BASE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging
+METHODOLOGY_PDF_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf
+
+# Recurring ETL schedule gate. Set to true only in the ECS service that should enqueue recurring imports.
+ETL_SCHEDULE_ENABLED=false
 
 # AWS credentials (only needed for ETL pipeline — not required for local dev with seed data)
 # AWS_ACCESS_KEY_ID=

--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ Built for [EPIC](https://www.policyinnovation.org/) (Environmental Policy Innova
 | `MAPBOX_ACCESS_TOKEN` | Yes | Mapbox GL JS token for map rendering |
 | `MAPBOX_STYLE_URL` | Yes | Mapbox Style URL for account specific styling config |
 | `DB_PORT` | No | PostgreSQL port (default `5432`). Only needed if your Docker container is mapped to a non-default port to avoid a conflict with a local PostgreSQL install — see `docker-compose.override.yml`. |
-| `ETL_SOURCE_URL` | Yes (setup + ETL) | Base HTTPS URL to the S3 folder containing source data files. Required for `bin/setup` and the ETL pipeline. No AWS credentials needed — the bucket is publicly readable. |
+| `ETL_SOURCE_URL` | Yes (setup + ETL) | Base HTTPS URL to the S3 folder containing source data files. Staging should point at the S3 `staging` folder; production should point at `prod`. No AWS credentials needed for public reads. |
+| `PUBLIC_DOWNLOADS_BASE_URL` | Yes (deployed app) | Base HTTPS URL for ZIP downloads shown in the Downloads panel. Staging should use the S3 `public-data-downloads/staging` folder; production should use `public-data-downloads/prod`. |
+| `METHODOLOGY_PDF_URL` | Yes (deployed app) | Full HTTPS URL for the methodology/documentation PDF. |
+| `APP_ENV` | Yes (ECS) | Runtime app environment: `staging`, `production`, or `preview`. ECS services may share `RAILS_ENV=production`, so use this for app-level environment identity. |
+| `ETL_SCHEDULE_ENABLED` | No | Set to `true` only in the deployment that should enqueue recurring ETL imports. Defaults to off. |
 | `RAILS_ENV` | No | Defaults to `development` |
 
 ---

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -24,6 +24,14 @@ module HomeHelper
     DATASETS
   end
 
+  def download_url(path)
+    "#{AppConfig.public_downloads_base_url}/#{path.to_s.delete_prefix("/")}"
+  end
+
+  def methodology_pdf_url
+    AppConfig.methodology_pdf_url
+  end
+
   def filter_tooltips
     FILTER_TOOLTIPS
   end

--- a/app/services/app_config.rb
+++ b/app/services/app_config.rb
@@ -1,0 +1,39 @@
+class AppConfig
+  S3_BASE_URL = "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool"
+  METHODOLOGY_PDF_PATH = "public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf"
+
+  class << self
+    def app_env
+      ENV["APP_ENV"].presence || Rails.env.to_s
+    end
+
+    def public_downloads_base_url
+      env_url("PUBLIC_DOWNLOADS_BASE_URL") || "#{S3_BASE_URL}/public-data-downloads/#{s3_environment_folder}"
+    end
+
+    def methodology_pdf_url
+      env_url("METHODOLOGY_PDF_URL") || "#{S3_BASE_URL}/#{METHODOLOGY_PDF_PATH}"
+    end
+
+    def etl_schedule_enabled?
+      ENV["ETL_SCHEDULE_ENABLED"] == "true"
+    end
+
+    private
+
+    def env_url(name)
+      ENV[name].presence&.chomp("/")
+    end
+
+    def s3_environment_folder
+      case app_env
+      when "production"
+        "prod"
+      when "staging"
+        "staging"
+      else
+        "staging"
+      end
+    end
+  end
+end

--- a/app/views/home/_core_section_nav.html.erb
+++ b/app/views/home/_core_section_nav.html.erb
@@ -17,7 +17,7 @@
   <%= render UI::NavItemComponent.new(
         label: "Documentation",
         icon_name: "documentation",
-        href: "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf",
+        href: methodology_pdf_url,
         external: true
       ) %>
 </li>

--- a/app/views/home/_datasets.html.erb
+++ b/app/views/home/_datasets.html.erb
@@ -16,7 +16,7 @@
           This inventory of drinking water datasets includes information from various public data providers.
           You can learn details about specific sources and considerations for use below.
           Please visit the
-          <%= render UI::ExternalLinkComponent.new(url: "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf", classes: "text-brand-primary", aria_label: "Drinking Water Explorer methodology documentation (PDF)") do %>documentation<% end %>
+          <%= render UI::ExternalLinkComponent.new(url: methodology_pdf_url, classes: "text-brand-primary", aria_label: "Drinking Water Explorer methodology documentation (PDF)") do %>documentation<% end %>
           for additional information and caveats.
         </p>
       </div>

--- a/app/views/home/_downloads.html.erb
+++ b/app/views/home/_downloads.html.erb
@@ -1,5 +1,3 @@
-<% s3_base = "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged" %>
-
 <div class="px-4 md:px-9 pt-4 pb-8">
   <h3 class="m-0 mb-3 font-bold">Downloads</h3>
   <p class="mb-4 text-neutral-700">Below, you'll find geospatial and tabular data for states, territories, and the nation as a zipped package.</p>
@@ -14,12 +12,12 @@
 
   <div class="border-t border-gray-200 pt-6">
     <div class="mb-4">
-      <%= render UI::DownloadLinkComponent.new(url: "#{s3_base}/national-dw-tool-staged.zip") do %>National<% end %>
+      <%= render UI::DownloadLinkComponent.new(url: download_url("national-dw-tool.zip")) do %>National<% end %>
     </div>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-4">
       <% download_states.each do |code, name| %>
         <div>
-          <%= render UI::DownloadLinkComponent.new(url: "#{s3_base}/states/#{code}.zip") do %><%= name %><% end %>
+          <%= render UI::DownloadLinkComponent.new(url: download_url("states/#{code}.zip")) do %><%= name %><% end %>
         </div>
       <% end %>
     </div>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -10,17 +10,16 @@
 #     schedule: at 5am every day
 
 production:
-  # Production-only: ETL_SOURCE_URL and S3 credentials are only configured in
-  # the production environment. Staging/review environments skip this schedule
-  # intentionally — run etl:import manually there if needed.
-  #
+<% if ENV["ETL_SCHEDULE_ENABLED"] == "true" %>
+  # Enabled explicitly per deployment with ETL_SCHEDULE_ENABLED=true.
   # Runs daily at 6am in the timezone configured via config.time_zone (default UTC).
   # Coordinate with EPIC's data team to ensure this fires after the S3 manifest
   # is refreshed upstream.
   etl_import:
     class: EtlImportJob
     queue: etl
-    schedule: every day at 12am America/New_York 
+    schedule: every day at 12am America/New_York
+<% end %>
 
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -311,6 +311,20 @@ The workflow reads these from the repository's **Settings → Secrets and variab
 | `STAGING_URL` | `https://water-data-tool-staging.policyinnovation.info/` |
 | `SERVICE_BUILDER_IMAGE_URI` | `516937823875.dkr.ecr.us-east-1.amazonaws.com/ep_service_builder:latest` |
 
+### App environment variables
+
+Set these in the ECS task definition or deployment workflow for each environment:
+
+| Name | Staging | Production | Preview |
+|---|---|---|---|
+| `APP_ENV` | `staging` | `production` | `preview` |
+| `ETL_SOURCE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/prod` | staging or PR-specific S3 folder |
+| `PUBLIC_DOWNLOADS_BASE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/prod` | staging or PR-specific downloads folder |
+| `METHODOLOGY_PDF_URL` | Full methodology PDF URL | Full methodology PDF URL | Full methodology PDF URL |
+| `ETL_SCHEDULE_ENABLED` | `false` unless staging should run recurring imports | `true` only if production should run recurring imports | `false` |
+
+Do not use `RAILS_ENV` to distinguish staging from production app behavior. ECS services run Rails in production mode, so `APP_ENV` is the app-level environment identity and `ETL_SCHEDULE_ENABLED` is the recurring ETL gate.
+
 ### Secrets
 
 | Name | What it is |
@@ -324,14 +338,16 @@ The workflow reads these from the repository's **Settings → Secrets and variab
 
 ### Data population strategy
 
-All three databases (`water_data_tool_production`, `water_data_tool_staging`, `water_data_tool_preview`) start empty after provisioning. Only production self-populates automatically via the recurring SolidQueue ETL job. Staging and preview need an explicit strategy:
+All three databases (`water_data_tool_production`, `water_data_tool_staging`, `water_data_tool_preview`) start empty after provisioning. Staging and production should populate from their own S3 folders via ETL:
 
-**Staging** — recommended: schedule a weekly `pg_dump` of the production DB piped into a `pg_restore` against staging. Both databases live on the same RDS instance so there is no network egress cost. This keeps staging representative of production without waiting for ETL to run independently.
+**Staging** — set `APP_ENV=staging`, `ETL_SOURCE_URL` to the S3 `staging` folder, and `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/staging`. Run `bin/rails etl:import` manually or set `ETL_SCHEDULE_ENABLED=true` if staging should maintain its own recurring imports.
 
 ```bash
-# Run from within the VPC (e.g. SSH to an ECS host)
-pg_dump "$PROD_URL" | psql "$STAGING_URL"
+# Via ECS exec after container is healthy
+bin/rails etl:import
 ```
+
+**Production** — set `APP_ENV=production`, `ETL_SOURCE_URL` to the S3 `prod` folder, `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/prod`, and `ETL_SCHEDULE_ENABLED=true` only in the production service that should enqueue recurring imports.
 
 **PR / preview** — recommended: trigger a one-time state seed after the PR environment comes up, using the app's existing seed task. A few states is enough to exercise all features including the map.
 
@@ -345,9 +361,9 @@ aws ecs execute-command \
   --command "bin/rails 'db:seed:states[VT,RI,OH,CO]'"
 ```
 
-This seed command pulls public data from S3 over HTTPS — no AWS credentials required. It could be added as a post-deploy step directly in the `pr-deploy` workflow job once the ECS task is confirmed healthy.
+This seed command pulls public data from S3 over HTTPS using `ETL_SOURCE_URL` — no AWS credentials required. It could be added as a post-deploy step directly in the `pr-deploy` workflow job once the ECS task is confirmed healthy.
 
-Neither strategy is wired up yet — both are day-two operational items before staging and PR environments are used for meaningful review work.
+Preview data seeding is still a day-two operational item before PR environments are used for meaningful review work.
 
 ---
 

--- a/docs/ETL.md
+++ b/docs/ETL.md
@@ -28,7 +28,7 @@ S3 Bucket (ETL_SOURCE_URL)
 
 The data publisher overwrites files in place at the same S3 keys. The ETL issues an HTTP HEAD request per file, reads the `Last-Modified` header, and imports any files whose timestamp is newer than the last recorded import in the `data_imports` table. No manifest file is needed.
 
-There is no per-environment S3 bucket — a single bucket serves development, staging, and production. The `ETL_SOURCE_URL` env var controls which folder path each environment reads from. Confirm with the EPIC data team that staging and production point to the correct folder (production data, not test data) before go-live.
+There is no per-environment S3 bucket — a single bucket serves development, staging, and production. The `ETL_SOURCE_URL` env var controls which folder path each environment reads from. Staging should point at the S3 `staging` folder, and production should point at the S3 `prod` folder.
 
 ---
 
@@ -234,13 +234,17 @@ bin/rails etl:import[epa_sabs,force]
 Configure a recurring job in `config/recurring.yml`:
 
 ```yaml
-etl_import:
-  class: EtlImportJob
-  queue: etl
-  schedule: every day at 12am America/New_York
+production:
+  # Rendered only when ETL_SCHEDULE_ENABLED=true
+  etl_import:
+    class: EtlImportJob
+    queue: etl
+    schedule: every day at 12am America/New_York
 ```
 
 The job runs on the dedicated `etl` queue and has a concurrency limit so imports cannot overlap. It issues HEAD requests per file and only imports files with updated `Last-Modified` timestamps. If a source omits `Last-Modified`, the file imports as changed.
+
+Because staging, production, and preview ECS services may all use `RAILS_ENV=production`, recurring ETL is gated by `ETL_SCHEDULE_ENABLED=true` rather than Rails environment alone. Leave the variable unset or false anywhere recurring imports should not run.
 
 ---
 

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -1,6 +1,28 @@
 require "rails_helper"
 
 RSpec.describe HomeHelper, type: :helper do
+  def with_modified_env(values)
+    previous = values.keys.to_h { |key| [key, ENV[key]] }
+    values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
+  describe "environment-backed public asset URLs" do
+    it "builds download URLs from PUBLIC_DOWNLOADS_BASE_URL" do
+      with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => "https://cdn.example.test/downloads/staging/") do
+        expect(helper.download_url("states/CO.zip")).to eq("https://cdn.example.test/downloads/staging/states/CO.zip")
+      end
+    end
+
+    it "uses METHODOLOGY_PDF_URL for documentation links" do
+      with_modified_env("METHODOLOGY_PDF_URL" => "https://cdn.example.test/methodology.pdf") do
+        expect(helper.methodology_pdf_url).to eq("https://cdn.example.test/methodology.pdf")
+      end
+    end
+  end
+
   describe "#hidden_inputs_for_params" do
     before do
       allow(helper).to receive(:request).and_return(

--- a/spec/jobs/queue_config_spec.rb
+++ b/spec/jobs/queue_config_spec.rb
@@ -23,3 +23,34 @@ RSpec.describe "Solid Queue config" do
     expect(default_worker.fetch("threads")).to eq(1)
   end
 end
+
+RSpec.describe "Solid Queue recurring config" do
+  def with_modified_env(values)
+    previous = values.keys.to_h { |key| [key, ENV[key]] }
+    values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
+  def recurring_config(schedule_enabled:)
+    with_modified_env("ETL_SCHEDULE_ENABLED" => schedule_enabled) do
+      YAML.safe_load(
+        ERB.new(Rails.root.join("config/recurring.yml").read).result,
+        aliases: true
+      )
+    end
+  end
+
+  it "includes the recurring ETL job when ETL_SCHEDULE_ENABLED is true" do
+    production_config = recurring_config(schedule_enabled: "true").fetch("production")
+
+    expect(production_config).to include("etl_import" => hash_including("class" => "EtlImportJob"))
+  end
+
+  it "omits the recurring ETL job when ETL_SCHEDULE_ENABLED is not true" do
+    production_config = recurring_config(schedule_enabled: nil).fetch("production")
+
+    expect(production_config).not_to have_key("etl_import")
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "Home", type: :request do
+  def with_modified_env(values)
+    previous = values.keys.to_h { |key| [key, ENV[key]] }
+    values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
   describe "GET /" do
     it "returns 200" do
       get root_path
@@ -8,24 +16,41 @@ RSpec.describe "Home", type: :request do
     end
 
     it "renders the downloads section with a national download link" do
-      get root_path
-      expect(response.body).to include("national-dw-tool-staged.zip")
+      with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => "https://cdn.example.test/downloads/prod") do
+        get root_path
+      end
+
+      expect(response.body).to include("https://cdn.example.test/downloads/prod/national-dw-tool.zip")
     end
 
     it "renders state download links" do
-      get root_path
-      expect(response.body).to include("states/CO.zip")
+      with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => "https://cdn.example.test/downloads/staging") do
+        get root_path
+      end
+
+      expect(response.body).to include("https://cdn.example.test/downloads/staging/states/CO.zip")
       expect(response.body).to include("Colorado")
-      expect(response.body).to include("states/VT.zip")
+      expect(response.body).to include("https://cdn.example.test/downloads/staging/states/VT.zip")
       expect(response.body).to include("Vermont")
     end
 
     it "renders territory download links" do
-      get root_path
-      expect(response.body).to include("states/PR.zip")
+      with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => "https://cdn.example.test/downloads/staging") do
+        get root_path
+      end
+
+      expect(response.body).to include("https://cdn.example.test/downloads/staging/states/PR.zip")
       expect(response.body).to include("Puerto Rico")
-      expect(response.body).to include("states/GU.zip")
+      expect(response.body).to include("https://cdn.example.test/downloads/staging/states/GU.zip")
       expect(response.body).to include("Guam")
+    end
+
+    it "renders methodology links from METHODOLOGY_PDF_URL" do
+      with_modified_env("METHODOLOGY_PDF_URL" => "https://cdn.example.test/methodology.pdf") do
+        get root_path
+      end
+
+      expect(response.body).to include("https://cdn.example.test/methodology.pdf")
     end
 
     it "renders the datasets catalog with all 27 dataset cards" do

--- a/spec/services/app_config_spec.rb
+++ b/spec/services/app_config_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe AppConfig do
+  def with_modified_env(values)
+    previous = values.keys.to_h { |key| [key, ENV[key]] }
+    values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
+  describe ".app_env" do
+    it "uses APP_ENV when present" do
+      with_modified_env("APP_ENV" => "staging") do
+        expect(described_class.app_env).to eq("staging")
+      end
+    end
+
+    it "falls back to the Rails environment" do
+      with_modified_env("APP_ENV" => nil) do
+        expect(described_class.app_env).to eq(Rails.env.to_s)
+      end
+    end
+  end
+
+  describe ".public_downloads_base_url" do
+    it "uses PUBLIC_DOWNLOADS_BASE_URL when present and removes a trailing slash" do
+      with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => "https://cdn.example.test/downloads/staging/") do
+        expect(described_class.public_downloads_base_url).to eq("https://cdn.example.test/downloads/staging")
+      end
+    end
+
+    it "generates the staging S3 downloads folder for APP_ENV=staging" do
+      with_modified_env("APP_ENV" => "staging", "PUBLIC_DOWNLOADS_BASE_URL" => nil) do
+        expect(described_class.public_downloads_base_url)
+          .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging")
+      end
+    end
+
+    it "generates the production S3 downloads folder for APP_ENV=production" do
+      with_modified_env("APP_ENV" => "production", "PUBLIC_DOWNLOADS_BASE_URL" => nil) do
+        expect(described_class.public_downloads_base_url)
+          .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/prod")
+      end
+    end
+  end
+
+  describe ".methodology_pdf_url" do
+    it "uses METHODOLOGY_PDF_URL when present" do
+      with_modified_env("METHODOLOGY_PDF_URL" => "https://cdn.example.test/methodology.pdf") do
+        expect(described_class.methodology_pdf_url).to eq("https://cdn.example.test/methodology.pdf")
+      end
+    end
+  end
+
+  describe ".etl_schedule_enabled?" do
+    it "is true only when ETL_SCHEDULE_ENABLED is true" do
+      with_modified_env("ETL_SCHEDULE_ENABLED" => "true") do
+        expect(described_class.etl_schedule_enabled?).to be(true)
+      end
+
+      with_modified_env("ETL_SCHEDULE_ENABLED" => nil) do
+        expect(described_class.etl_schedule_enabled?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/cartographic_boundaries_spec.rb
+++ b/spec/services/cartographic_boundaries_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CartographicBoundaries do
   describe "#load" do
     around do |example|
       original = ENV["ETL_SOURCE_URL"]
-      ENV["ETL_SOURCE_URL"] = "https://tech-team-data.s3.amazonaws.com/national-dw-tool/test-staged"
+      ENV["ETL_SOURCE_URL"] = "https://tech-team-data.s3.amazonaws.com/national-dw-tool/staging"
       example.run
     ensure
       ENV["ETL_SOURCE_URL"] = original
@@ -56,7 +56,7 @@ RSpec.describe CartographicBoundaries do
         "us_place_500k.shp"
       ])
       expect(instance.send(:zip_url, described_class::LAYERS.second)).to eq(
-        "https://tech-team-data.s3.amazonaws.com/national-dw-tool/test-staged/cartographic-boundaries/us_county_500k.zip"
+        "https://tech-team-data.s3.amazonaws.com/national-dw-tool/staging/cartographic-boundaries/us_county_500k.zip"
       )
     end
 

--- a/spec/services/etl/importer_spec.rb
+++ b/spec/services/etl/importer_spec.rb
@@ -229,6 +229,28 @@ RSpec.describe Etl::Importer do
       expect(epa_sabs["http_path"]).to eq("https://s3.example.com/data/epa_sabs.csv")
     end
 
+    it "constructs file URLs from the staging ETL_SOURCE_URL" do
+      ENV["ETL_SOURCE_URL"] = "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging"
+      filtered_importer = described_class.new(only: "epa_sabs")
+      allow(filtered_importer).to receive(:head_url).and_return(mock_response)
+
+      entries = filtered_importer.send(:build_file_entries)
+
+      expect(entries.sole["http_path"])
+        .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging/epa_sabs.csv")
+    end
+
+    it "constructs file URLs from the production ETL_SOURCE_URL" do
+      ENV["ETL_SOURCE_URL"] = "https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/prod"
+      filtered_importer = described_class.new(only: "epa_sabs")
+      allow(filtered_importer).to receive(:head_url).and_return(mock_response)
+
+      entries = filtered_importer.send(:build_file_entries)
+
+      expect(entries.sole["http_path"])
+        .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/prod/epa_sabs.csv")
+    end
+
     it "uses .geojson extension for the geometry file" do
       entries = importer.send(:build_file_entries)
       geoms = entries.find { |e| e["file_key"] == "epa_sabs_geoms" }


### PR DESCRIPTION
## Relevant Ticket
https://github.com/Environmental-Policy-Innovation-Center/water-data-tool/issues/199

## Summary

Moves environment-specific S3 behavior out of hard-coded staging URLs so ECS staging, production, and preview can all run with `RAILS_ENV=production` while still using the correct deployment identity. Adds app-level config for public downloads, methodology links, ETL source folders, and the recurring import gate.

## Changes

- Centralizes public asset URL configuration behind `AppConfig`, with `PUBLIC_DOWNLOADS_BASE_URL` and `METHODOLOGY_PDF_URL` taking precedence over environment-derived defaults.
- Updates the Downloads and Documentation links to resolve from runtime configuration instead of fixed `public-data-downloads/staged` paths.
- Aligns ETL source configuration with the AC for separate S3 folders: staging reads from `national-dw-tool/staging`, production reads from `national-dw-tool/prod`, and tests now assert both URL shapes.
- Uses `APP_ENV` as the app-level deployment identity so staging, production, and preview can behave differently even when ECS runs them all with `RAILS_ENV=production`.
- Gates the recurring SolidQueue ETL schedule with `ETL_SCHEDULE_ENABLED=true`, so only the intended ECS service enqueues `EtlImportJob` while staging/preview can stay manual by default.
- Documents the required deployment variables and data-population strategy for staging, production, and preview, including the expected `PUBLIC_DOWNLOADS_BASE_URL`, `ETL_SOURCE_URL`, and `ETL_SCHEDULE_ENABLED` values.
- Adds coverage for the AC-critical paths: config fallback behavior, env-backed public links, rendered home-page download/documentation URLs, recurring schedule inclusion/exclusion, and staging/prod ETL source URL construction.

## Notes for reviewers

The main review focus is whether the deployment env var contract matches the desired operational setup: `APP_ENV` identifies staging/prod/preview behavior, `ETL_SOURCE_URL` controls import inputs, `PUBLIC_DOWNLOADS_BASE_URL` controls rendered ZIP links, and `ETL_SCHEDULE_ENABLED` is the only switch that enables recurring imports.
