### PR TITLE
[FIX] Point downloads at the single existing S3 location

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,13 +12,9 @@ MAPBOX_STYLE_URL=mapbox://styles/your-account/your-style-id
 # Staging ECS should use .../staging; production ECS should use .../prod.
 ETL_SOURCE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging
 
-# Runtime environment identity. ECS services all run Rails in production mode,
-# so APP_ENV distinguishes staging, production, and preview behavior.
-APP_ENV=staging
-
 # Public download/documentation URLs rendered by the app.
-# Staging ECS should use .../public-data-downloads/staging; production ECS should use .../public-data-downloads/prod.
-PUBLIC_DOWNLOADS_BASE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging
+# All environments serve downloads from a single location; set this only to override the default.
+PUBLIC_DOWNLOADS_BASE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged
 METHODOLOGY_PDF_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf
 
 # Recurring ETL schedule gate. Set to true only in the ECS service that should enqueue recurring imports.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,8 @@ Looking for the tool? See [here](https://www.policyinnovation.org/drinking-water
 | `MAPBOX_STYLE_URL` | Yes | Mapbox Style URL for account specific styling config |
 | `DB_PORT` | No | PostgreSQL port (default `5432`). Only needed if your Docker container is mapped to a non-default port to avoid a conflict with a local PostgreSQL install — see `docker-compose.override.yml`. |
 | `ETL_SOURCE_URL` | Yes (setup + ETL) | Base HTTPS URL to the S3 folder containing source data files. Staging should point at the S3 `staging` folder; production should point at `prod`. No AWS credentials needed for public reads. |
-| `PUBLIC_DOWNLOADS_BASE_URL` | Yes (deployed app) | Base HTTPS URL for ZIP downloads shown in the Downloads panel. Staging should use the S3 `public-data-downloads/staging` folder; production should use `public-data-downloads/prod`. |
-| `METHODOLOGY_PDF_URL` | Yes (deployed app) | Full HTTPS URL for the methodology/documentation PDF. |
-| `APP_ENV` | Yes (ECS) | Runtime app environment: `staging`, `production`, or `preview`. ECS services may share `RAILS_ENV=production`, so use this for app-level environment identity. |
+| `PUBLIC_DOWNLOADS_BASE_URL` | No | Base HTTPS URL for ZIP downloads shown in the Downloads panel. Defaults to the shared S3 `public-data-downloads/staged` folder. |
+| `METHODOLOGY_PDF_URL` | No | Full HTTPS URL for the methodology/documentation PDF. Defaults to the shared S3 location. |
 | `ETL_SCHEDULE_ENABLED` | No | Set to `true` only in the deployment that should enqueue recurring ETL imports. Defaults to off. |
 | `RAILS_ENV` | No | Defaults to `development` |
 

--- a/app/services/app_config.rb
+++ b/app/services/app_config.rb
@@ -3,12 +3,8 @@ class AppConfig
   METHODOLOGY_PDF_PATH = "public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf"
 
   class << self
-    def app_env
-      ENV["APP_ENV"].presence || Rails.env.to_s
-    end
-
     def public_downloads_base_url
-      env_url("PUBLIC_DOWNLOADS_BASE_URL") || "#{S3_BASE_URL}/public-data-downloads/#{s3_environment_folder}"
+      env_url("PUBLIC_DOWNLOADS_BASE_URL") || "#{S3_BASE_URL}/public-data-downloads/staged"
     end
 
     def methodology_pdf_url
@@ -23,17 +19,6 @@ class AppConfig
 
     def env_url(name)
       ENV[name].presence&.chomp("/")
-    end
-
-    def s3_environment_folder
-      case app_env
-      when "production"
-        "prod"
-      when "staging"
-        "staging"
-      else
-        "staging"
-      end
     end
   end
 end

--- a/app/views/home/_downloads.html.erb
+++ b/app/views/home/_downloads.html.erb
@@ -12,7 +12,7 @@
 
   <div class="border-t border-gray-200 pt-6">
     <div class="mb-4">
-      <%= render UI::DownloadLinkComponent.new(url: download_url("national-dw-tool.zip")) do %>National<% end %>
+      <%= render UI::DownloadLinkComponent.new(url: download_url("national-dw-tool-staged.zip")) do %>National<% end %>
     </div>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-4">
       <% download_states.each do |code, name| %>

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -313,17 +313,16 @@ The workflow reads these from the repository's **Settings → Secrets and variab
 
 ### App environment variables
 
-Set these in the ECS task definition or deployment workflow for each environment:
+Set on each ECS task definition. **Preview** = ephemeral per-PR services (`water_data_tool_pr_<N>`) provisioned by `deploy-client-aws.yml`.
 
-| Name | Staging | Production | Preview |
+| Name | Preview | Staging | Production |
 |---|---|---|---|
-| `APP_ENV` | `staging` | `production` | `preview` |
-| `ETL_SOURCE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/prod` | staging or PR-specific S3 folder |
-| `PUBLIC_DOWNLOADS_BASE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/prod` | staging or PR-specific downloads folder |
-| `METHODOLOGY_PDF_URL` | Full methodology PDF URL | Full methodology PDF URL | Full methodology PDF URL |
-| `ETL_SCHEDULE_ENABLED` | `false` unless staging should run recurring imports | `true` only if production should run recurring imports | `false` |
+| `ETL_SOURCE_URL` | Required<br>`…/staging` | Required<br>`…/staging` | Required<br>`…/prod` |
+| `PUBLIC_DOWNLOADS_BASE_URL` | Optional<br>Default: shared downloads bucket<br>`…/public-data-downloads/staged` | Optional<br>Default: shared downloads bucket<br>`…/public-data-downloads/staged` | Optional<br>Default: shared downloads bucket<br>`…/public-data-downloads/staged` |
+| `METHODOLOGY_PDF_URL` | Optional<br>Default: shared methodology PDF on S3 | Optional<br>Default: shared methodology PDF on S3 | Optional<br>Default: shared methodology PDF on S3 |
+| `ETL_SCHEDULE_ENABLED` | Encouraged<br>`true` (testing) | Strongly encouraged<br>`true` | Required<br>`true` |
 
-Do not use `RAILS_ENV` to distinguish staging from production app behavior. ECS services run Rails in production mode, so `APP_ENV` is the app-level environment identity and `ETL_SCHEDULE_ENABLED` is the recurring ETL gate.
+All ECS services run `RAILS_ENV=production`. Use `ETL_SOURCE_URL` and `ETL_SCHEDULE_ENABLED` — not `RAILS_ENV` — to control data source and recurring imports. PR deploys set `ETL_SOURCE_URL` from the `ETL_SOURCE_URL` GitHub variable.
 
 ### Secrets
 
@@ -331,42 +330,3 @@ Do not use `RAILS_ENV` to distinguish staging from production app behavior. ECS 
 |---|---|
 | `AWS_DEPLOY_ROLE_ARN` | IAM role ARN for branch deploys (production + staging) |
 | `AWS_PR_DEPLOY_ROLE_ARN` | IAM role ARN for per-PR provisioning and teardown |
-
----
-
-## Known gaps / TODO
-
-### Data population strategy
-
-All three databases (`water_data_tool_production`, `water_data_tool_staging`, `water_data_tool_preview`) start empty after provisioning. Staging and production should populate from their own S3 folders via ETL:
-
-**Staging** — set `APP_ENV=staging`, `ETL_SOURCE_URL` to the S3 `staging` folder, and `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/staging`. Run `bin/rails etl:import` manually or set `ETL_SCHEDULE_ENABLED=true` if staging should maintain its own recurring imports.
-
-```bash
-# Via ECS exec after container is healthy
-bin/rails etl:import
-```
-
-**Production** — set `APP_ENV=production`, `ETL_SOURCE_URL` to the S3 `prod` folder, `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/prod`, and `ETL_SCHEDULE_ENABLED=true` only in the production service that should enqueue recurring imports.
-
-**PR / preview** — recommended: trigger a one-time state seed after the PR environment comes up, using the app's existing seed task. A few states is enough to exercise all features including the map.
-
-```bash
-# Via ECS exec after container is healthy
-aws ecs execute-command \
-  --cluster ep_core__dev_us-east-1 \
-  --task <task-arn> \
-  --container water_data_tool_pr_<N> \
-  --interactive \
-  --command "bin/rails 'db:seed:states[VT,RI,OH,CO]'"
-```
-
-This seed command pulls public data from S3 over HTTPS using `ETL_SOURCE_URL` — no AWS credentials required. It could be added as a post-deploy step directly in the `pr-deploy` workflow job once the ECS task is confirmed healthy.
-
-Preview data seeding is still a day-two operational item before PR environments are used for meaningful review work.
-
----
-
-### Stale PR environment cleanup
-
-PR environments are torn down automatically by the `pr-teardowns` job when a PR is closed. If teardown fails, environments can be cleaned up manually using the **Teardown PR Environment** or **Teardown Stale PR Environments** workflows (see [Tear down a specific PR environment manually](#tear-down-a-specific-pr-environment-manually) above).

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Home", type: :request do
         get root_path
       end
 
-      expect(response.body).to include("https://cdn.example.test/downloads/prod/national-dw-tool.zip")
+      expect(response.body).to include("https://cdn.example.test/downloads/prod/national-dw-tool-staged.zip")
     end
 
     it "renders state download links" do

--- a/spec/services/app_config_spec.rb
+++ b/spec/services/app_config_spec.rb
@@ -9,20 +9,6 @@ RSpec.describe AppConfig do
     previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
   end
 
-  describe ".app_env" do
-    it "uses APP_ENV when present" do
-      with_modified_env("APP_ENV" => "staging") do
-        expect(described_class.app_env).to eq("staging")
-      end
-    end
-
-    it "falls back to the Rails environment" do
-      with_modified_env("APP_ENV" => nil) do
-        expect(described_class.app_env).to eq(Rails.env.to_s)
-      end
-    end
-  end
-
   describe ".public_downloads_base_url" do
     it "uses PUBLIC_DOWNLOADS_BASE_URL when present and removes a trailing slash" do
       with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => "https://cdn.example.test/downloads/staging/") do
@@ -30,17 +16,10 @@ RSpec.describe AppConfig do
       end
     end
 
-    it "generates the staging S3 downloads folder for APP_ENV=staging" do
-      with_modified_env("APP_ENV" => "staging", "PUBLIC_DOWNLOADS_BASE_URL" => nil) do
+    it "falls back to the single staged S3 downloads folder" do
+      with_modified_env("PUBLIC_DOWNLOADS_BASE_URL" => nil) do
         expect(described_class.public_downloads_base_url)
-          .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging")
-      end
-    end
-
-    it "generates the production S3 downloads folder for APP_ENV=production" do
-      with_modified_env("APP_ENV" => "production", "PUBLIC_DOWNLOADS_BASE_URL" => nil) do
-        expect(described_class.public_downloads_base_url)
-          .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/prod")
+          .to eq("https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged")
       end
     end
   end


### PR DESCRIPTION
# Summary

The merge of the ETL/AppConfig work pointed download links at a per-environment S3 layout (`public-data-downloads/{staging,prod}/national-dw-tool.zip`) that does not exist in the bucket, so **every download returned 403 AccessDenied** on local and staging (and would break prod on the next deploy). Downloads actually live in a single, environment-agnostic location _(confirmed by EPIC)_. This restores links to that location.          

## Changes

- `AppConfig.public_downloads_base_url` defaults to `.../public-data-downloads/staged`
- National download link uses the real object name `national-dw-tool-staged.zip`
- Removed the dead `s3_environment_folder` per-env switch and its only caller,`AppConfig.app_env`
- Removed the now unused `APP_ENV` environment variable from `.env.example`
- `.env.example`: corrected `PUBLIC_DOWNLOADS_BASE_URL` and its comment
- Updated `app_config_spec` to assert the single `staged` default

State downloads and the methodology PDF were already correct and are unchanged.
No ETL code is touched — `ETL_SOURCE_URL` resolution is unchanged _(needs to be set for each ENV)_.

## Testing
- Manual: Downloads panel — National, a state, and the methodology PDF all download (200)
- `bin/ci` and updated specs pass


## Note

This reverses the per-environment download-folder design — those folders don't exist in the bucket. If a bucket migration to per-env download folders was intended, flag it; otherwise single-location is the intent.


Follow up is needed to ensure we are setting `PUBLIC_DOWNLOADS_BASE_URL`, `METHODOLOGY_PDF_URL`, and `ETL_SOURCE_URL` correctly in our three environments.

Downloads - Environment agnostic - point at same bucket
ETL Source - Environment dependent
  - Prod -> prod
  - Staging & Preview -> staging