### PR TITLE
[Refactor] Address Various Var & General Infra Cleanup Needs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,8 @@ ETL_SOURCE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-too
 APP_ENV=staging
 
 # Public download/documentation URLs rendered by the app.
-# Staging ECS should use .../public-data-downloads/staging; production ECS should use .../public-data-downloads/prod.
-PUBLIC_DOWNLOADS_BASE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging
+# Deployed environments currently use the staged public downloads folder.
+PUBLIC_DOWNLOADS_BASE_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged
 METHODOLOGY_PDF_URL=https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf
 
 # Recurring ETL schedule gate. Set to true only in the ECS service that should enqueue recurring imports.

--- a/.github/actions/teardown-pr/action.yml
+++ b/.github/actions/teardown-pr/action.yml
@@ -67,23 +67,4 @@ runs:
     - name: Destroy PR environment via service_builder
       shell: bash
       run: |
-        docker run --rm \
-          -e EP_ACTION=destroy \
-          -e EP_ENV="pr-${{ inputs.pr_number }}" \
-          -e EP_SERVICE_NAME="water_data_tool_pr_${{ inputs.pr_number }}" \
-          -e EP_SERVICE_SHORT_NAME="pr${{ inputs.pr_number }}" \
-          -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
-          -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
-          -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
-          -e EP_SERVICE_INSTANCE_COUNT="1" \
-          -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
-          -e EP_SERVICE_DOMAIN="water-data-tool-pr-${{ inputs.pr_number }}.policyinnovation.info" \
-          -e EP_SERVICE_PORT="3000" \
-          -e EP_SERVICE_HEALTH_PORT="3000" \
-          -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
-          -e EP_CREATE_ECR_REPO="false" \
-          -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-          -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-          -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
-          -e AWS_REGION="$AWS_REGION" \
-          "$SERVICE_BUILDER_IMAGE"
+        "$GITHUB_WORKSPACE/script/teardown_pr_environment" "${{ inputs.pr_number }}"

--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -100,6 +100,7 @@ jobs:
             {"name":"HTTP_PORT",           "value":"3000"},
             {"name":"TARGET_PORT",         "value":"3001"},
             {"name":"ETL_SOURCE_URL",      "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging"},
+            {"name":"ETL_SCHEDULE_ENABLED", "value":"true"},
             {"name":"PUBLIC_DOWNLOADS_BASE_URL", "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged"},
             {"name":"METHODOLOGY_PDF_URL", "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC'\''s+Drinking+Water+Explorer+Tool+-+Methodology.pdf"}
           ]'

--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -95,11 +95,14 @@ jobs:
 
           ENV_VARS_JSON='[
             {"name":"RAILS_ENV",           "value":"production"},
+            {"name":"APP_ENV",             "value":"preview"},
             {"name":"RAILS_LOG_TO_STDOUT", "value":"1"},
             {"name":"SOLID_QUEUE_IN_PUMA", "value":"true"},
             {"name":"HTTP_PORT",           "value":"3000"},
             {"name":"TARGET_PORT",         "value":"3001"},
-            {"name":"ETL_SOURCE_URL",      "value":"${{ vars.ETL_SOURCE_URL }}"}
+            {"name":"ETL_SOURCE_URL",      "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging"},
+            {"name":"PUBLIC_DOWNLOADS_BASE_URL", "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged"},
+            {"name":"METHODOLOGY_PDF_URL", "value":"https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC'\''s+Drinking+Water+Explorer+Tool+-+Methodology.pdf"}
           ]'
 
           docker run --rm \

--- a/.github/workflows/deploy-client-aws.yml
+++ b/.github/workflows/deploy-client-aws.yml
@@ -95,7 +95,6 @@ jobs:
 
           ENV_VARS_JSON='[
             {"name":"RAILS_ENV",           "value":"production"},
-            {"name":"APP_ENV",             "value":"preview"},
             {"name":"RAILS_LOG_TO_STDOUT", "value":"1"},
             {"name":"SOLID_QUEUE_IN_PUMA", "value":"true"},
             {"name":"HTTP_PORT",           "value":"3000"},

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -102,7 +102,7 @@ jobs:
             echo "|---|---|"
             echo "| **SHA** | \`${DEPLOY_SHA:0:8}\` |"
             echo "| **ECR tag** | \`staging-${DEPLOY_SHA}\` |"
-            echo "| **Staging URL** | ${{ vars.STAGING_URL }} |"
+            echo "| **Staging URL** | https://water-data-tool-staging.policyinnovation.info/ |"
             echo "| **Triggered by** | @${{ github.actor }} |"
             echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -134,7 +134,7 @@ jobs:
             echo "|---|---|"
             echo "| **Image digest** | \`$DIGEST\` |"
             echo "| **ECR tag** | \`$IMMUTABLE_TAG\` |"
-            echo "| **Production URL** | https://water-data-tool.policyinnovation.info/ |"
+            echo "| **Production URL** | https://watertool.policyinnovation.info/ |"
             echo "| **Triggered by** | @${{ github.actor }} |"
             echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -134,7 +134,7 @@ jobs:
             echo "|---|---|"
             echo "| **Image digest** | \`$DIGEST\` |"
             echo "| **ECR tag** | \`$IMMUTABLE_TAG\` |"
-            echo "| **Production URL** | ${{ vars.PROD_URL }} |"
+            echo "| **Production URL** | https://water-data-tool.policyinnovation.info/ |"
             echo "| **Triggered by** | @${{ github.actor }} |"
             echo "| **Time** | $(date -u '+%Y-%m-%d %H:%M UTC') |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/teardown-stale-pr-envs.yml
+++ b/.github/workflows/teardown-stale-pr-envs.yml
@@ -33,6 +33,8 @@ jobs:
       SERVICE_BUILDER_IMAGE: ${{ vars.SERVICE_BUILDER_IMAGE_URI }}
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Configure AWS credentials (PR role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -108,26 +110,7 @@ jobs:
                 --source-group "$NODE_SG_ID" || true
             fi
 
-            docker run --rm \
-              -e EP_ACTION=destroy \
-              -e EP_ENV="pr-${PR_NUM}" \
-              -e EP_SERVICE_NAME="water_data_tool_pr_${PR_NUM}" \
-              -e EP_SERVICE_SHORT_NAME="pr${PR_NUM}" \
-              -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
-              -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
-              -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
-              -e EP_SERVICE_INSTANCE_COUNT="1" \
-              -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
-              -e EP_SERVICE_DOMAIN="water-data-tool-pr-${PR_NUM}.policyinnovation.info" \
-              -e EP_SERVICE_PORT="3000" \
-              -e EP_SERVICE_HEALTH_PORT="3000" \
-              -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
-              -e EP_CREATE_ECR_REPO="false" \
-              -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-              -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-              -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
-              -e AWS_REGION="$AWS_REGION" \
-              "$SERVICE_BUILDER_IMAGE"
+            "$GITHUB_WORKSPACE/script/teardown_pr_environment" "$PR_NUM"
 
             gh pr close "${PR_NUM}" \
               --repo "$GITHUB_REPOSITORY" \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Looking for the tool? See [here](https://www.policyinnovation.org/drinking-water
 
 
 ## Current Deployed Instances
-- **Production**: https://water-data-tool.policyinnovation.info
+- **Production**: https://watertool.policyinnovation.info
 - **Staging**: https://water-data-tool-staging.policyinnovation.info
 - **PR previews**: https://water-data-tool-pr-\<N\>.policyinnovation.info (spun up automatically for each open PR)
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Looking for the tool? See [here](https://www.policyinnovation.org/drinking-water
 | `MAPBOX_STYLE_URL` | Yes | Mapbox Style URL for account specific styling config |
 | `DB_PORT` | No | PostgreSQL port (default `5432`). Only needed if your Docker container is mapped to a non-default port to avoid a conflict with a local PostgreSQL install — see `docker-compose.override.yml`. |
 | `ETL_SOURCE_URL` | Yes (setup + ETL) | Base HTTPS URL to the S3 folder containing source data files. Staging should point at the S3 `staging` folder; production should point at `prod`. No AWS credentials needed for public reads. |
-| `PUBLIC_DOWNLOADS_BASE_URL` | Yes (deployed app) | Base HTTPS URL for ZIP downloads shown in the Downloads panel. Staging should use the S3 `public-data-downloads/staging` folder; production should use `public-data-downloads/prod`. |
+| `PUBLIC_DOWNLOADS_BASE_URL` | Yes (deployed app) | Base HTTPS URL for ZIP downloads shown in the Downloads panel. Deployed environments currently use the S3 `public-data-downloads/staged` folder. |
 | `METHODOLOGY_PDF_URL` | Yes (deployed app) | Full HTTPS URL for the methodology/documentation PDF. |
 | `APP_ENV` | Yes (ECS) | Runtime app environment: `staging`, `production`, or `preview`. ECS services may share `RAILS_ENV=production`, so use this for app-level environment identity. |
 | `ETL_SCHEDULE_ENABLED` | No | Set to `true` only in the deployment that should enqueue recurring ETL imports. Defaults to off. |

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -307,7 +307,7 @@ The workflow reads these from the repository's **Settings → Secrets and variab
 | `ECS_CLUSTER` | `ep_core__dev_us-east-1` |
 | `ECS_SERVICE_PROD` | `ep_app__water_data_tool__dev_us-east-1` |
 | `ECS_SERVICE_STAGING` | `ep_app__water_data_tool_staging__dev_us-east-1` |
-| `RDS_SG_ID` | RDS security group ID used by PR preview deploys |
+| `RDS_SG_ID` | RDS security group ID used by PR preview deploy/teardown workflows. This is a GitHub repository variable, not an app `.env` value. |
 | `SERVICE_BUILDER_IMAGE_URI` | `516937823875.dkr.ecr.us-east-1.amazonaws.com/ep_service_builder:latest` |
 
 ### App environment variables
@@ -319,9 +319,9 @@ Set on each ECS task definition. **Preview** = ephemeral per-PR services (`water
 | `ETL_SOURCE_URL` | Required<br>`…/staging` | Required<br>`…/staging` | Required<br>`…/prod` |
 | `PUBLIC_DOWNLOADS_BASE_URL` | Optional<br>Default: shared downloads bucket<br>`…/public-data-downloads/staged` | Optional<br>Default: shared downloads bucket<br>`…/public-data-downloads/staged` | Optional<br>Default: shared downloads bucket<br>`…/public-data-downloads/staged` |
 | `METHODOLOGY_PDF_URL` | Optional<br>Default: shared methodology PDF on S3 | Optional<br>Default: shared methodology PDF on S3 | Optional<br>Default: shared methodology PDF on S3 |
-| `ETL_SCHEDULE_ENABLED` | unset or `false` | Strongly encouraged<br>`true` | Required<br>`true` |
+| `ETL_SCHEDULE_ENABLED` | `true` | Strongly encouraged<br>`true` | Required<br>`true` |
 
-All ECS services run `RAILS_ENV=production`. Use `ETL_SOURCE_URL` and `ETL_SCHEDULE_ENABLED` — not `RAILS_ENV` — to control data source and recurring imports. `PUBLIC_DOWNLOADS_BASE_URL` and `METHODOLOGY_PDF_URL` have shared S3 defaults, though deploy workflows may still pass explicit values for clarity. PR deploys set `ETL_SOURCE_URL` directly to the staging S3 folder and leave recurring ETL off because PR environments share the preview database.
+All ECS services run `RAILS_ENV=production`. Use `ETL_SOURCE_URL` and `ETL_SCHEDULE_ENABLED` — not `RAILS_ENV` — to control data source and recurring imports. `PUBLIC_DOWNLOADS_BASE_URL` and `METHODOLOGY_PDF_URL` have shared S3 defaults, though deploy workflows may still pass explicit values for clarity. PR deploys set `ETL_SOURCE_URL` directly to the staging S3 folder and enable recurring ETL; all PR environments share the preview database, so `EtlImportJob` concurrency and S3 `Last-Modified` checks keep overlapping nightly runs serialized and mostly no-op when source files are unchanged.
 
 ### Secrets
 
@@ -347,21 +347,7 @@ bin/rails etl:import
 
 **Production** — set `ETL_SOURCE_URL` to the S3 `prod` folder, keep `PUBLIC_DOWNLOADS_BASE_URL` on `public-data-downloads/staged`, and set `ETL_SCHEDULE_ENABLED=true`.
 
-**PR / preview** — recommended: trigger a one-time state seed after the PR environment comes up, using the app's existing seed task. A few states is enough to exercise all features including the map.
-
-```bash
-# Via ECS exec after container is healthy
-aws ecs execute-command \
-  --cluster ep_core__dev_us-east-1 \
-  --task <task-arn> \
-  --container water_data_tool_pr_<N> \
-  --interactive \
-  --command "bin/rails 'db:seed:states[VT,RI,OH,CO]'"
-```
-
-This seed command pulls public data from S3 over HTTPS using `ETL_SOURCE_URL` — no AWS credentials required. It could be added as a post-deploy step directly in the `pr-deploy` workflow job once the ECS task is confirmed healthy.
-
-Preview data seeding is still a day-two operational item before PR environments are used for meaningful review work.
+**PR / preview** — recurring ETL is enabled in each preview service. Preview imports read from the staging S3 folder and share the `water_data_tool_preview` database across PRs. ECS exec is disabled; if immediate preview data is needed before the nightly schedule runs, define and run a one-off ECS task for `bin/rails etl:import`, usually with other container memory reservations scaled down so the task can fit on the cluster.
 
 ---
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -307,8 +307,7 @@ The workflow reads these from the repository's **Settings → Secrets and variab
 | `ECS_CLUSTER` | `ep_core__dev_us-east-1` |
 | `ECS_SERVICE_PROD` | `ep_app__water_data_tool__dev_us-east-1` |
 | `ECS_SERVICE_STAGING` | `ep_app__water_data_tool_staging__dev_us-east-1` |
-| `PROD_URL` | `https://water-data-tool.policyinnovation.info/` |
-| `STAGING_URL` | `https://water-data-tool-staging.policyinnovation.info/` |
+| `RDS_SG_ID` | RDS security group ID used by PR preview deploys |
 | `SERVICE_BUILDER_IMAGE_URI` | `516937823875.dkr.ecr.us-east-1.amazonaws.com/ep_service_builder:latest` |
 
 ### App environment variables
@@ -318,10 +317,10 @@ Set these in the ECS task definition or deployment workflow for each environment
 | Name | Staging | Production | Preview |
 |---|---|---|---|
 | `APP_ENV` | `staging` | `production` | `preview` |
-| `ETL_SOURCE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/prod` | staging or PR-specific S3 folder |
-| `PUBLIC_DOWNLOADS_BASE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/prod` | staging or PR-specific downloads folder |
-| `METHODOLOGY_PDF_URL` | Full methodology PDF URL | Full methodology PDF URL | Full methodology PDF URL |
-| `ETL_SCHEDULE_ENABLED` | `false` unless staging should run recurring imports | `true` only if production should run recurring imports | `false` |
+| `ETL_SOURCE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/prod` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/staging` |
+| `PUBLIC_DOWNLOADS_BASE_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/staged` |
+| `METHODOLOGY_PDF_URL` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf` | `https://tech-team-data.s3.us-east-1.amazonaws.com/national-dw-tool/public-data-downloads/EPIC's+Drinking+Water+Explorer+Tool+-+Methodology.pdf` |
+| `ETL_SCHEDULE_ENABLED` | `true` | `true` | unset or `false` |
 
 Do not use `RAILS_ENV` to distinguish staging from production app behavior. ECS services run Rails in production mode, so `APP_ENV` is the app-level environment identity and `ETL_SCHEDULE_ENABLED` is the recurring ETL gate.
 
@@ -340,14 +339,14 @@ Do not use `RAILS_ENV` to distinguish staging from production app behavior. ECS 
 
 All three databases (`water_data_tool_production`, `water_data_tool_staging`, `water_data_tool_preview`) start empty after provisioning. Staging and production should populate from their own S3 folders via ETL:
 
-**Staging** — set `APP_ENV=staging`, `ETL_SOURCE_URL` to the S3 `staging` folder, and `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/staging`. Run `bin/rails etl:import` manually or set `ETL_SCHEDULE_ENABLED=true` if staging should maintain its own recurring imports.
+**Staging** — set `APP_ENV=staging`, `ETL_SOURCE_URL` to the S3 `staging` folder, `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/staged`, and `ETL_SCHEDULE_ENABLED=true`.
 
 ```bash
 # Via ECS exec after container is healthy
 bin/rails etl:import
 ```
 
-**Production** — set `APP_ENV=production`, `ETL_SOURCE_URL` to the S3 `prod` folder, `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/prod`, and `ETL_SCHEDULE_ENABLED=true` only in the production service that should enqueue recurring imports.
+**Production** — set `APP_ENV=production`, `ETL_SOURCE_URL` to the S3 `prod` folder, `PUBLIC_DOWNLOADS_BASE_URL` to `public-data-downloads/staged`, and `ETL_SCHEDULE_ENABLED=true`.
 
 **PR / preview** — recommended: trigger a one-time state seed after the PR environment comes up, using the app's existing seed task. A few states is enough to exercise all features including the map.
 

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -15,7 +15,7 @@ There are three environments. Pushing to `main` does **not** trigger a deploy �
 | **Trigger** | GitHub Actions → **Promote Staging to Production** | GitHub Actions → **Deploy to Staging** | PR opened/updated against `main` |
 | **Teardown** | Manual | Manual | Automatic on PR close |
 | **ECS service** | `ep_app__water_data_tool__dev_us-east-1` | `ep_app__water_data_tool_staging__dev_us-east-1` | `ep_app__water_data_tool_pr_<N>__dev_us-east-1` |
-| **URL** | `water-data-tool.policyinnovation.info` | `water-data-tool-staging.policyinnovation.info` | `water-data-tool-pr-<N>.policyinnovation.info` |
+| **URL** | `watertool.policyinnovation.info` | `water-data-tool-staging.policyinnovation.info` | `water-data-tool-pr-<N>.policyinnovation.info` |
 | **Database** | `water_data_tool_production` | `water_data_tool_staging` | `water_data_tool_preview` (shared across all PRs) |
 | **ECR image tags** | `prod-promoted-<digest>`, `prod-latest` | `staging-<sha>`, `staging-latest` | `pr-<N>-<sha>`, `pr-<N>-latest` |
 | **IAM role** | `ep_gha__water_data_tool` | `ep_gha__water_data_tool` | `ep_gha__water_data_tool_pr` |
@@ -166,7 +166,7 @@ There is also a `pr-teardowns` environment used exclusively by the two manual te
 
 ```bash
 # Production
-curl -fsSI https://water-data-tool.policyinnovation.info/up
+curl -fsSI https://watertool.policyinnovation.info/up
 
 # Staging
 curl -fsSI https://water-data-tool-staging.policyinnovation.info/up

--- a/script/teardown_pr_environment
+++ b/script/teardown_pr_environment
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_NUM="${1:-${PR_NUM:-}}"
+
+if [[ ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "Usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+ALB_LOG_BUCKET="ep-app--water-data-tool-pr-${PR_NUM}-alb-logs--dev-us-east-1-epic"
+
+bucket_exists() {
+  aws s3api head-bucket --bucket "$ALB_LOG_BUCKET" >/dev/null 2>&1
+}
+
+delete_versioned_objects() {
+  local versions_file delete_file
+  versions_file="$(mktemp)"
+  delete_file="$(mktemp)"
+
+  aws s3api list-object-versions \
+    --bucket "$ALB_LOG_BUCKET" \
+    --output json > "$versions_file"
+
+  jq -c '
+    [
+      (.Versions // [])[] | {Key: .Key, VersionId: .VersionId}
+    ] + [
+      (.DeleteMarkers // [])[] | {Key: .Key, VersionId: .VersionId}
+    ] | {Objects: ., Quiet: true}
+  ' "$versions_file" > "$delete_file"
+
+  if jq -e '.Objects | length > 0' "$delete_file" >/dev/null; then
+    aws s3api delete-objects \
+      --bucket "$ALB_LOG_BUCKET" \
+      --delete "file://$delete_file" >/dev/null
+  fi
+
+  rm -f "$versions_file" "$delete_file"
+}
+
+empty_alb_log_bucket() {
+  if ! bucket_exists; then
+    echo "ALB log bucket not found: $ALB_LOG_BUCKET"
+    return 0
+  fi
+
+  echo "Emptying ALB log bucket: $ALB_LOG_BUCKET"
+  aws s3 rm "s3://$ALB_LOG_BUCKET" --recursive --only-show-errors
+  delete_versioned_objects
+}
+
+empty_and_delete_alb_log_bucket() {
+  if ! bucket_exists; then
+    echo "ALB log bucket already gone: $ALB_LOG_BUCKET"
+    return 0
+  fi
+
+  empty_alb_log_bucket
+  echo "Deleting ALB log bucket: $ALB_LOG_BUCKET"
+  aws s3api delete-bucket --bucket "$ALB_LOG_BUCKET" >/dev/null || true
+}
+
+run_service_builder_destroy() {
+  docker run --rm \
+    -e EP_ACTION=destroy \
+    -e EP_ENV="pr-${PR_NUM}" \
+    -e EP_SERVICE_NAME="water_data_tool_pr_${PR_NUM}" \
+    -e EP_SERVICE_SHORT_NAME="pr${PR_NUM}" \
+    -e EP_ECS_CLUSTER_NAME="$ECS_CLUSTER" \
+    -e EP_TF_STATE_S3_BUCKET_NAME="ep-service-builder" \
+    -e EP_SERVICE_INSTANCE_TYPE="t3.small" \
+    -e EP_SERVICE_INSTANCE_COUNT="1" \
+    -e EP_SERVICE_CONTAINER_RAM_MB="1700" \
+    -e EP_SERVICE_DOMAIN="water-data-tool-pr-${PR_NUM}.policyinnovation.info" \
+    -e EP_SERVICE_PORT="3000" \
+    -e EP_SERVICE_HEALTH_PORT="3000" \
+    -e EP_SERVICE_HEALTH_CHECK_PATH="/up" \
+    -e EP_CREATE_ECR_REPO="false" \
+    -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+    -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    -e AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+    -e AWS_REGION="$AWS_REGION" \
+    "$SERVICE_BUILDER_IMAGE"
+}
+
+empty_alb_log_bucket
+
+set +e
+run_service_builder_destroy
+destroy_status=$?
+set -e
+
+empty_and_delete_alb_log_bucket
+
+if [ "$destroy_status" -ne 0 ]; then
+  echo "service_builder destroy failed with status $destroy_status; retrying once after ALB log bucket cleanup."
+  set +e
+  run_service_builder_destroy
+  retry_status=$?
+  set -e
+
+  if [ "$retry_status" -ne 0 ]; then
+    echo "service_builder destroy retry failed with status $retry_status." >&2
+    exit "$retry_status"
+  fi
+fi

--- a/script/test_teardown_pr_environment
+++ b/script/test_teardown_pr_environment
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CALL_LOG="$TMP_DIR/calls.log"
+DOCKER_COUNT="$TMP_DIR/docker-count"
+echo 0 > "$DOCKER_COUNT"
+touch "$CALL_LOG"
+
+cat > "$TMP_DIR/aws" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "aws $*" >> "$CALL_LOG"
+
+case "$1 $2" in
+  "s3api head-bucket")
+    exit 0
+    ;;
+  "s3 rm")
+    exit 0
+    ;;
+  "s3api list-object-versions")
+    cat <<'JSON'
+{
+  "Versions": [
+    {"Key": "AWSLogs/123/current.log", "VersionId": "v1"}
+  ],
+  "DeleteMarkers": [
+    {"Key": "AWSLogs/123/deleted.log", "VersionId": "d1"}
+  ]
+}
+JSON
+    ;;
+  "s3api delete-objects")
+    exit 0
+    ;;
+  "s3api delete-bucket")
+    exit 0
+    ;;
+esac
+STUB
+
+cat > "$TMP_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "docker $*" >> "$CALL_LOG"
+count="$(cat "$DOCKER_COUNT")"
+count=$((count + 1))
+echo "$count" > "$DOCKER_COUNT"
+
+if [ "$count" -eq 1 ]; then
+  exit 42
+fi
+exit 0
+STUB
+
+chmod +x "$TMP_DIR/aws" "$TMP_DIR/docker"
+
+export PATH="$TMP_DIR:$PATH"
+export CALL_LOG
+export DOCKER_COUNT
+export AWS_ACCESS_KEY_ID=test-access-key
+export AWS_SECRET_ACCESS_KEY=test-secret-key
+export AWS_SESSION_TOKEN=test-session-token
+export AWS_REGION=us-east-1
+export ECS_CLUSTER=ep_core__dev_us-east-1
+export SERVICE_BUILDER_IMAGE=service-builder:test
+
+"$ROOT_DIR/script/teardown_pr_environment" 243
+
+EXPECTED_BUCKET="ep-app--water-data-tool-pr-243-alb-logs--dev-us-east-1-epic"
+
+grep -q "aws s3api head-bucket --bucket $EXPECTED_BUCKET" "$CALL_LOG"
+grep -q "aws s3 rm s3://$EXPECTED_BUCKET --recursive --only-show-errors" "$CALL_LOG"
+grep -q "aws s3api delete-objects --bucket $EXPECTED_BUCKET" "$CALL_LOG"
+grep -q "aws s3api delete-bucket --bucket $EXPECTED_BUCKET" "$CALL_LOG"
+grep -q -- "-e EP_ACTION=destroy" "$CALL_LOG"
+grep -q -- "-e EP_ENV=pr-243" "$CALL_LOG"
+grep -q -- "-e EP_SERVICE_NAME=water_data_tool_pr_243" "$CALL_LOG"
+grep -q -- "-e EP_SERVICE_SHORT_NAME=pr243" "$CALL_LOG"
+
+if [ "$(cat "$DOCKER_COUNT")" -ne 2 ]; then
+  echo "expected service_builder destroy to be retried once" >&2
+  exit 1
+fi
+
+first_empty_line="$(grep -n "aws s3 rm s3://$EXPECTED_BUCKET" "$CALL_LOG" | head -1 | cut -d: -f1)"
+first_docker_line="$(grep -n "docker run --rm" "$CALL_LOG" | head -1 | cut -d: -f1)"
+if [ "$first_empty_line" -ge "$first_docker_line" ]; then
+  echo "expected bucket emptying before first service_builder destroy" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Align deployed environment configuration so PR previews no longer depend on ambiguous repository variables, while keeping `main`'s shared S3 defaults for public downloads and methodology links. Also make PR preview teardown resilient to ALB log buckets that can block Terraform destroy.

## Changes

- Make PR preview deploys self-contained by setting the preview ETL source directly to the staging S3 folder and leaving recurring ETL off for shared preview database safety.
- Keep the shared public download and methodology URL behavior from `main`: those values default to shared S3 locations and only need to be set when overriding the defaults, though deploy workflows may still pass explicit values for clarity.
- Remove workflow dependence on summary-only URL repository variables by writing the production and staging URLs directly in deploy summaries.
- Document the intended deployment variables, including the required ETL source per environment, optional shared download/methodology overrides, and the repo variables that should remain.
- Route both manual PR teardown and stale PR cleanup through a shared teardown helper that empties and deletes PR ALB log buckets, removes versioned objects/delete markers, and retries `service_builder` destroy once after cleanup.
- Add a focused teardown script test that stubs AWS and Docker calls to verify bucket cleanup happens before destroy and that failed destroy is retried.

## Notes for reviewers

Rollout order:

1. Before approval, run CI and `terraform plan` in the infra repo to confirm the companion ECS task-definition changes are limited to the expected environment variables. Do not run `terraform apply` before approval unless the team explicitly wants to change live production/staging configuration ahead of review.
2. After approval, merge this app PR so PR preview deploys no longer depend on `vars.ETL_SOURCE_URL` and teardown workflows use the S3 cleanup helper.
3. Remove obsolete GitHub repository variables after this workflow change is merged: `ETL_SOURCE_URL`, `PROD_URL`, and `STAGING_URL`. Keep deploy-critical variables such as `AWS_DEPLOY_ENABLED`, `AWS_REGION`, `ECR_REPO_URI`, `ECS_CLUSTER`, `ECS_SERVICE_PROD`, `ECS_SERVICE_STAGING`, `RDS_SG_ID`, and `SERVICE_BUILDER_IMAGE_URI`.
4. Apply the companion infra change for persistent ECS services: production should read `/prod`, staging should read `/staging`, both should set `ETL_SCHEDULE_ENABLED=true`, and download/methodology vars may be omitted to use the app defaults or set explicitly to the shared S3 values for clarity.
5. After apply, confirm ECS services stabilize, check `/up` for production and staging, inspect task-definition env vars, and watch logs for recurring ETL behavior.

Validation performed locally:

- `script/test_teardown_pr_environment`
- workflow YAML parse via Ruby
- `actionlint -shellcheck ''` on changed workflows
- `bash -n` on teardown scripts
- `bundle exec rspec spec/services/app_config_spec.rb spec/requests/home_spec.rb`
