### PR TITLE
[REFACTOR] Generalize Filterable for joined radio/multiselect filters + checked_value for bool

### DIFF
--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -82,7 +82,7 @@ module Filterable
     def filter_active?(field, params)
       case field.filter_kind
       when :range then params[:"#{field.filter_param}_min"].present? || params[:"#{field.filter_param}_max"].present?
-      when :bool then param_value(field, params) == "true"
+      when :bool then param_value(field, params) == bool_checked_value(field).to_s
       when :radio then param_value(field, params).present?
       when :multiselect then multiselect_values(field, params).any?
       end
@@ -91,7 +91,7 @@ module Filterable
     def filter_predicate(field, params)
       case field.filter_kind
       when :range then range_predicate(field, params)
-      when :bool then Arel::Table.new(field.table)[field.filter_column].eq(true)
+      when :bool then Arel::Table.new(field.table)[field.filter_column].eq(bool_checked_value(field))
       when :radio then Arel::Table.new(field.table)[field.filter_column].eq(param_value(field, params))
       when :multiselect then Arel::Table.new(field.table)[field.filter_column].in(multiselect_values(field, params))
       end
@@ -103,6 +103,11 @@ module Filterable
 
     def multiselect_values(field, params)
       Array(param_value(field, params)).select(&:present?)
+    end
+
+    # Defaults to real true; filter.checked_value overrides it for non-boolean columns.
+    def bool_checked_value(field)
+      field.filter[:checked_value] || true
     end
 
     def range_predicate(field, params)

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -16,20 +16,13 @@ module Filterable
 
     private
 
-    # Radio + multiselect filters. Each is its own single-filter category, so each ANDs (OR-of-one).
+    # Passthrough params with no owning manifest field.
     def apply_direct_filters(scope, params)
-      scope = scope.where(gw_sw_code: params[:gw_sw_code]) if params[:gw_sw_code].present?
-      scope = scope.where(owner_type: params[:owner_type]) if params[:owner_type].present?
-      scope = scope.where(primacy_type: params[:primacy_type]) if params[:primacy_type].present?
-      scope = scope.where(pop_cat_5: params[:pop_cat_5]) if params[:pop_cat_5].present?
-      scope = scope.where(symbology_field: params[:symbology_field]) if params[:symbology_field].present?
       scope = scope.where(stusps: params[:state]) if params[:state].present?
       scope
     end
 
-    # Range + bool filters combined per the layout: filters within one category OR together (one
-    # .where), and categories AND with one another. Column/table/coercion/join come from the manifest.
-    # A field not placed in the layout (URL-only) is its own AND group. See docs/FILTERING.md.
+    # OR within a category, AND across categories — see category_groups and docs/FILTERING.md.
     def apply_category_filters(scope, joined, params)
       category_groups.each do |fields|
         active = fields.select { |f| filter_active?(f, params) }
@@ -42,8 +35,7 @@ module Filterable
       [scope, joined]
     end
 
-    # Rate tier is a multiselect with custom value mapping (tier slug → stored enum), so it stays
-    # out of the generic range applier. Its tiers OR; the filter ANDs with the rest.
+    # Kept out of the generic path — needs tier slug → stored enum translation before hitting SQL.
     def apply_rate_tier_filter(scope, joined, params)
       tiers = Array(params[:most_common_rate_tier]).select(&:present?)
       return [scope, joined] if tiers.empty?
@@ -77,11 +69,12 @@ module Filterable
       scope
     end
 
-    # Range + bool fields grouped into OR-sets by layout category; a field not placed in the layout
-    # (URL-only) is its own AND singleton.
+    # Grouped by layout category (OR within, AND across); ungrouped fields are singletons.
+    # most_common_rate_tier is excluded — see apply_rate_tier_filter.
     def category_groups
       FieldRegistry.fields
-        .select { |f| [:range, :bool].include?(f.filter_kind) }
+        .select { |f| [:range, :bool, :radio, :multiselect].include?(f.filter_kind) }
+        .reject { |f| f.key == :most_common_rate_tier }
         .group_by { |f| FilterLayout.category_of[f.key] }
         .flat_map { |category, fields| category ? [fields] : fields.zip }
     end
@@ -89,7 +82,9 @@ module Filterable
     def filter_active?(field, params)
       case field.filter_kind
       when :range then params[:"#{field.filter_param}_min"].present? || params[:"#{field.filter_param}_max"].present?
-      when :bool then params[field.filter[:param].to_sym] == "true"
+      when :bool then param_value(field, params) == "true"
+      when :radio then param_value(field, params).present?
+      when :multiselect then multiselect_values(field, params).any?
       end
     end
 
@@ -97,7 +92,17 @@ module Filterable
       case field.filter_kind
       when :range then range_predicate(field, params)
       when :bool then Arel::Table.new(field.table)[field.filter_column].eq(true)
+      when :radio then Arel::Table.new(field.table)[field.filter_column].eq(param_value(field, params))
+      when :multiselect then Arel::Table.new(field.table)[field.filter_column].in(multiselect_values(field, params))
       end
+    end
+
+    def param_value(field, params)
+      params[field.filter[:param].to_sym]
+    end
+
+    def multiselect_values(field, params)
+      Array(param_value(field, params)).select(&:present?)
     end
 
     def range_predicate(field, params)

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -107,7 +107,7 @@ module Filterable
 
     # Defaults to real true; filter.checked_value overrides it for non-boolean columns.
     def bool_checked_value(field)
-      field.filter[:checked_value] || true
+      field.filter.fetch(:checked_value, true)
     end
 
     def range_predicate(field, params)

--- a/app/views/home/_filter_bool.html.erb
+++ b/app/views/home/_filter_bool.html.erb
@@ -3,7 +3,7 @@
 <% param = field.filter[:param] %>
 <li class="<%= filter_row_classes %>">
   <input type="checkbox" class="toggle" id="<%= filter_checkbox_id(param) %>"
-         data-filter-kind="bool" data-filter-param="<%= param %>" data-filter-value="true" data-filter-group="<%= group %>"
+         data-filter-kind="bool" data-filter-param="<%= param %>" data-filter-value="<%= field.filter[:checked_value] || "true" %>" data-filter-group="<%= group %>"
          <%= checked_if filter_active?(param) %>>
   <label for="<%= filter_checkbox_id(param) %>"><%= field.filter[:label] %></label>
   <% if field.filter[:tooltip] %><%= tooltip_icon(filter_tooltips[field.filter[:tooltip]]) %><% end %>

--- a/config/fields.yml
+++ b/config/fields.yml
@@ -44,6 +44,7 @@
 #       coercion: decimal               #   decimal | integer (range only)
 #       label: "Poverty rate"           #   MENU label (often differs from display.label; omit for radio/multiselect — they use options)
 #       tooltip: poverty_rate           #   tooltips.yml key (omit if none)
+#       checked_value: Certified        #   bool only — value compared against when checked (omit → real boolean true)
 #       has_select_all: true            #   multiselect only — render a select-all/deselect-all control (omit → none)
 #       options:                        #   radio + multiselect ONLY — the discrete choices (range/bool never use it); list one block per choice
 #         - {value: GW, label: "Ground only", default: true}   #   value stored, label shown; default: true = selected at load

--- a/config/fields.yml
+++ b/config/fields.yml
@@ -163,7 +163,6 @@ fields:
 
   symbology_field:
     model: public_water_system
-    db_column: service_area_type
     display: {label: "Boundary type", sort: symbology_field, format: str, csv_label: "Boundary type"}
     filter:
       kind: radio

--- a/docs/how_to/ADD_NEW_DATA_FIELD.md
+++ b/docs/how_to/ADD_NEW_DATA_FIELD.md
@@ -237,6 +237,8 @@ poverty_rate:
     format: percent               #   percent | currency | count | percent_change
 ```
 
+If you set `db_column`, know its blast radius: it only affects import (`FieldRegistry`'s ETL mapping) and export (`PublicWaterSystemExporter`'s CSV/GeoJSON column). Table display always reads the AR attribute named after the field *key*, never `db_column` — so a stale or wrong `db_column` silently exports a different column's value than what's shown on screen, with no error. See the `db_column` bullet under "Tests" below for the spec pattern that catches this.
+
 Notes for a filter:
 - **`kind`** picks the control: `range` (numeric slider), `radio` (one-of), `bool` (yes/no), `multiselect` (many-of). A numeric column → almost always `range`.
 - **`range` needs `coercion`** so the min/max are cast correctly — don't omit it on numeric filters.
@@ -341,6 +343,7 @@ Copy an existing field's assertions as your template — find one with the same 
 - **The import actually maps your file correctly (Path A)** → `spec/services/etl/importers/generic_spec.rb`. Drop a small fixture at `spec/fixtures/etl/my_new_file.csv` (a header row + a couple of data rows), then add a `#parse` assertion proving `header → column → cast` — e.g. `expect(parse_fixture("my_new_file").first).to include(my_field: <expected cast value>)`. This is the spec that confirms your data will import correctly, with **no S3 and no live DB needed**.
 - **Import wiring backstop** → `spec/services/etl/importer_coverage_spec.rb` enforces that every registered file is either generic-with-`source:` or listed in `custom_imports:` (never both). A new Path-A file must satisfy it — it's the check that catches a file registered in Step 2 but not wired in Step 3.
 - **Brand-new table, exported** → no new test needed, but `bin/ci`'s `spec/exporters/public_water_system_exporter_spec.rb` and `spec/requests/exports_spec.rb` will fail loudly (`PG::UndefinedTable: missing FROM-clause entry`) if Step 1's export join list entry was skipped — that's the existing coverage catching it, not a gap to fill.
+- **Set `db_column` on this field?** Add a value-assertion export spec: create a record with a distinct value for both the field's own column and whatever other column shares the table, export it, and assert the CSV cell equals the field's value (see `public_water_system_exporter_spec.rb`'s `"exports a field's own column value, not a different same-model column"` for the pattern). Nothing else in `bin/ci` checks this — a wrong `db_column` exports silently, with no error.
 
 ### 4. (Optional) Local dev data — how seeding works
 

--- a/docs/how_to/ADD_NEW_DATA_FIELD.md
+++ b/docs/how_to/ADD_NEW_DATA_FIELD.md
@@ -104,55 +104,63 @@ Reference: [Active Record Migrations](https://guides.rubyonrails.org/active_reco
 
 ### Brand-new table: the model, association, registry, factory, and spec
 
-Creating the table is only the first step — several more pieces go with it, all before you touch the manifest. Every existing satellite table (`demographics`, `watershed_hazards`, `boil_water_summaries`, …) follows the same shape; here's `certification_summaries` (added alongside the `rra_certification` field) as a concrete, real example.
+Creating the table is only the first step — several more pieces go with it, all before you touch the manifest. Every satellite table (`demographics`, `watershed_hazards`, `boil_water_summaries`, …) follows the same shape; here's `boil_water_summaries` as a concrete, real example.
 
-**1. The model** — `app/models/certification_summary.rb`:
+**1. The model** — `app/models/boil_water_summary.rb`:
 ```ruby
-class CertificationSummary < ApplicationRecord
-  belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :certification_summary
+class BoilWaterSummary < ApplicationRecord
+  belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :boil_water_summary
 
   validates :pwsid, presence: true
 end
 ```
-Just a `belongs_to` back to `PublicWaterSystem` and a presence validation on `pwsid` — that's the whole model for every satellite table in this app (add `include Histogrammable` only if one of the columns feeds a histogram). Don't hand-write the `# == Schema Information` comment block at the top — the `annotaterb` gem regenerates it automatically the next time a `db:*` task runs in development (see `lib/tasks/annotate_rb.rake`).
+Just a `belongs_to` back to `PublicWaterSystem` and a presence validation on `pwsid` — that's the whole model for every satellite table in this app (add `include Histogrammable` only if one of the columns feeds a histogram, as `WatershedHazard` does). Don't hand-write the `# == Schema Information` comment block at the top — the `annotaterb` gem regenerates it automatically the next time a `db:*` task runs in development (see `lib/tasks/annotate_rb.rake`).
 
-If the column holds a small fixed set of upstream values, a Rails `enum` is tempting — but only add one if something actually consumes its key-based interface, like `Demographic#most_common_rate_tier` (its key feeds `apply_rate_tier_filter`'s value translation and a dedicated `fmt_rate_tier` label lookup). An enum with nothing wired to it silently breaks table display: its reader returns the enum's *key* (`"certified"`), not the stored value (`"Certified"`) — this app added and then removed exactly that enum on `CertificationSummary` for this reason. Default to a plain string column; reach for `enum` only when you have a concrete second consumer for the key.
+If a column holds a small fixed set of upstream values, a Rails `enum` is tempting — but only add one if something actually consumes its key-based interface, like `Demographic#most_common_rate_tier` (its key feeds `apply_rate_tier_filter`'s value translation and a dedicated `fmt_rate_tier` label lookup). An enum with nothing wired to it silently breaks table display: its reader returns the enum's *key*, not the stored value. Default to a plain string column; reach for `enum` only when you have a concrete second consumer for the key.
 
 **2. The association** — add one line to `app/models/public_water_system.rb`, alongside its siblings:
 ```ruby
-has_one :certification_summary, foreign_key: "pwsid", inverse_of: :public_water_system, dependent: :destroy
+has_one :boil_water_summary, foreign_key: "pwsid", inverse_of: :public_water_system, dependent: :destroy
 ```
-This is the line Step 1's rule refers to — its name (`:certification_summary`) is exactly the `model:` value you'll write in `fields.yml` (Step 3).
+This is the line Step 1's rule refers to — its name (`:boil_water_summary`) is exactly the `model:` value you'll write in `fields.yml` (Step 3).
 
 **3. The manifest's model registry** — add one line to `MODEL_CLASSES` in `app/fields/field_registry.rb`, alongside its siblings:
 ```ruby
-certification_summary: "CertificationSummary"
+boil_water_summary: "BoilWaterSummary"
 ```
-This is a separate, hardcoded map from the manifest `model:` symbol to the actual Ruby class — `FieldRegistry.model_class` looks up here, not by guessing a class name from the symbol. Skip it and `fields.yml` will raise `KeyError: key not found` the moment Step 3 writes a field with `model: certification_summary` — do this now so that error never happens.
+This is a separate, hardcoded map from the manifest `model:` symbol to the actual Ruby class — `FieldRegistry.model_class` looks up here, not by guessing a class name from the symbol. Skip it and `fields.yml` will raise `KeyError: key not found` the moment Step 3 writes a field with `model: boil_water_summary` — do this now so that error never happens.
 
 **4. The export join list** — add one line to `ASSOCIATION_JOINS` in `app/exporters/public_water_system_exporter.rb`, alongside its siblings:
 ```ruby
-LEFT JOIN certification_summaries ON certification_summaries.pwsid = public_water_systems.pwsid
+LEFT JOIN boil_water_summaries ON boil_water_summaries.pwsid = public_water_systems.pwsid
 ```
 This is a third, separate hardcoded list every satellite table needs an entry in, powering CSV/GeoJSON export — it's unconditional, the same one-entry-per-`MODEL_CLASSES`-table shape as Step 1's model registry, not tied to whether any of the table's fields are displayed yet. Skip it and exporting any column later placed in `table_layout.yml` (Step 6) raises `PG::UndefinedTable: missing FROM-clause entry for table "..."` — do this now, alongside the model registry, so that error never happens.
 
-**5. The factory** — `spec/factories/certification_summaries.rb`, needed by any spec that builds one of these rows:
+**5. The factory** — `spec/factories/boil_water_summaries.rb`, needed by any spec that builds one of these rows:
 ```ruby
 FactoryBot.define do
-  factory :certification_summary do
+  factory :boil_water_summary do
     association :public_water_system
     pwsid { public_water_system.pwsid }
-    rra_certification { ["Certified", "Uncertified"].sample }
+    first_advisory_date { "2018-06-15" }
+    last_advisory_date { "2021-09-03" }
+    total_notices { 3 }
+    state_reporting_year_min { "2015" }
+    state_reporting_year_max { "2023" }
+    state { "Vermont" }
+    tooltip_text { "Vermont has reported boil water notices since 2015." }
+    download_url { "https://example.com/vt-bwn.csv" }
+    date_range_display { "2015–2023" }
   end
 end
 ```
-Most satellite factories default to one fixed value; this one varies since the field only has two states. Pin an explicit value in specs that need one: `build(:certification_summary, rra_certification: "Certified")`.
+Most satellite factories default to fixed values like this. If a field only has a couple of possible states, a factory can vary it instead (e.g. `{ ["Certified", "Uncertified"].sample }`) — pin an explicit value in specs that need one.
 
-**6. The model spec** — `spec/models/certification_summary_spec.rb`. Every satellite model spec in this app asserts the same two things and nothing more — the association and the presence validation:
+**6. The model spec** — `spec/models/boil_water_summary_spec.rb`. Every satellite model spec in this app asserts the same two things and nothing more — the association and the presence validation:
 ```ruby
 require "rails_helper"
 
-RSpec.describe CertificationSummary, type: :model do
+RSpec.describe BoilWaterSummary, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:public_water_system).with_foreign_key("pwsid") }
   end
@@ -162,9 +170,9 @@ RSpec.describe CertificationSummary, type: :model do
   end
 end
 ```
-Copy `spec/models/boil_water_summary_spec.rb` or `spec/models/watershed_hazard_spec.rb` verbatim and swap the class name — there's no field-specific behavior to test here; that belongs in the generic-importer spec (Step 7) instead.
+Copy this (or `spec/models/watershed_hazard_spec.rb`) verbatim and swap the class name — there's no field-specific behavior to test here; that belongs in the generic-importer spec (Step 7) instead.
 
-**Run it before touching the model.** `bundle exec rspec spec/models/certification_summary_spec.rb` should fail red with no `belongs_to` / `validates` yet — then fill in the model and rerun until green. Same Red → Green discipline `CLAUDE.md` mandates for every model, concern, and job in this app.
+**Run it before touching the model.** `bundle exec rspec spec/models/<model>_spec.rb` should fail red with no `belongs_to` / `validates` yet — then fill in the model and rerun until green. Same Red → Green discipline `CLAUDE.md` mandates for every model, concern, and job in this app.
 
 **Once it's green, re-annotate.** Run `bin/rails db:migrate` again — harmless with nothing pending, but it still fires the `annotaterb` hook (`lib/tasks/annotate_rb.rake`) — or run `bundle exec annotaterb models` directly. `.annotaterb.yml` has `exclude_factories: false` and `exclude_tests: false`, so this stamps the `# == Schema Information` block onto the factory and spec files too, not just the model.
 
@@ -242,7 +250,7 @@ If you set `db_column`, know its blast radius: it only affects import (`FieldReg
 Notes for a filter:
 - **`kind`** picks the control: `range` (numeric slider), `radio` (one-of), `bool` (yes/no), `multiselect` (many-of). A numeric column → almost always `range`.
 - **`range` needs `coercion`** so the min/max are cast correctly — don't omit it on numeric filters.
-- **`bool` on a non-boolean column needs `checked_value`.** The predicate defaults to comparing against a real boolean `true`; if the column is a two-value string instead (an enum-like column, e.g. `rra_certification`'s `Certified`/`Uncertified`), set `checked_value:` to whatever "checked" should compare against. See the `fields.yml` header for the shape and `rra_certification` for a real example.
+- **`bool` on a non-boolean column needs `checked_value`.** The predicate defaults to comparing against a real boolean `true`; if the column is a two-value string instead (an enum-like column, e.g. `Certified`/`Uncertified`), set `checked_value:` to whatever "checked" should compare against. See the `fields.yml` header for the shape.
 - **`radio` / `multiselect` need an `options:` list** instead of a `label`; `range` / `bool` never use `options`. See the `fields.yml` header for the `options:` shape.
 - **The URL param is permitted automatically.** `FieldRegistry.permit_arguments` (in `app/fields/field_registry.rb`) derives it from `filter.kind` — there is no permit code to edit.
 

--- a/docs/how_to/ADD_NEW_DATA_FIELD.md
+++ b/docs/how_to/ADD_NEW_DATA_FIELD.md
@@ -102,6 +102,72 @@ Reference: [Active Record Migrations](https://guides.rubyonrails.org/active_reco
 
 > `poverty_rate` example: it lives on the `demographic` table as a `decimal` column. A migration added that column before the manifest referenced it.
 
+### Brand-new table: the model, association, registry, factory, and spec
+
+Creating the table is only the first step — several more pieces go with it, all before you touch the manifest. Every existing satellite table (`demographics`, `watershed_hazards`, `boil_water_summaries`, …) follows the same shape; here's `certification_summaries` (added alongside the `rra_certification` field) as a concrete, real example.
+
+**1. The model** — `app/models/certification_summary.rb`:
+```ruby
+class CertificationSummary < ApplicationRecord
+  belongs_to :public_water_system, foreign_key: "pwsid", primary_key: "pwsid", inverse_of: :certification_summary
+
+  validates :pwsid, presence: true
+end
+```
+Just a `belongs_to` back to `PublicWaterSystem` and a presence validation on `pwsid` — that's the whole model for every satellite table in this app (add `include Histogrammable` only if one of the columns feeds a histogram). Don't hand-write the `# == Schema Information` comment block at the top — the `annotaterb` gem regenerates it automatically the next time a `db:*` task runs in development (see `lib/tasks/annotate_rb.rake`).
+
+If the column holds a small fixed set of upstream values, a Rails `enum` is tempting — but only add one if something actually consumes its key-based interface, like `Demographic#most_common_rate_tier` (its key feeds `apply_rate_tier_filter`'s value translation and a dedicated `fmt_rate_tier` label lookup). An enum with nothing wired to it silently breaks table display: its reader returns the enum's *key* (`"certified"`), not the stored value (`"Certified"`) — this app added and then removed exactly that enum on `CertificationSummary` for this reason. Default to a plain string column; reach for `enum` only when you have a concrete second consumer for the key.
+
+**2. The association** — add one line to `app/models/public_water_system.rb`, alongside its siblings:
+```ruby
+has_one :certification_summary, foreign_key: "pwsid", inverse_of: :public_water_system, dependent: :destroy
+```
+This is the line Step 1's rule refers to — its name (`:certification_summary`) is exactly the `model:` value you'll write in `fields.yml` (Step 3).
+
+**3. The manifest's model registry** — add one line to `MODEL_CLASSES` in `app/fields/field_registry.rb`, alongside its siblings:
+```ruby
+certification_summary: "CertificationSummary"
+```
+This is a separate, hardcoded map from the manifest `model:` symbol to the actual Ruby class — `FieldRegistry.model_class` looks up here, not by guessing a class name from the symbol. Skip it and `fields.yml` will raise `KeyError: key not found` the moment Step 3 writes a field with `model: certification_summary` — do this now so that error never happens.
+
+**4. The export join list** — add one line to `ASSOCIATION_JOINS` in `app/exporters/public_water_system_exporter.rb`, alongside its siblings:
+```ruby
+LEFT JOIN certification_summaries ON certification_summaries.pwsid = public_water_systems.pwsid
+```
+This is a third, separate hardcoded list every satellite table needs an entry in, powering CSV/GeoJSON export — it's unconditional, the same one-entry-per-`MODEL_CLASSES`-table shape as Step 1's model registry, not tied to whether any of the table's fields are displayed yet. Skip it and exporting any column later placed in `table_layout.yml` (Step 6) raises `PG::UndefinedTable: missing FROM-clause entry for table "..."` — do this now, alongside the model registry, so that error never happens.
+
+**5. The factory** — `spec/factories/certification_summaries.rb`, needed by any spec that builds one of these rows:
+```ruby
+FactoryBot.define do
+  factory :certification_summary do
+    association :public_water_system
+    pwsid { public_water_system.pwsid }
+    rra_certification { ["Certified", "Uncertified"].sample }
+  end
+end
+```
+Most satellite factories default to one fixed value; this one varies since the field only has two states. Pin an explicit value in specs that need one: `build(:certification_summary, rra_certification: "Certified")`.
+
+**6. The model spec** — `spec/models/certification_summary_spec.rb`. Every satellite model spec in this app asserts the same two things and nothing more — the association and the presence validation:
+```ruby
+require "rails_helper"
+
+RSpec.describe CertificationSummary, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:public_water_system).with_foreign_key("pwsid") }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:pwsid) }
+  end
+end
+```
+Copy `spec/models/boil_water_summary_spec.rb` or `spec/models/watershed_hazard_spec.rb` verbatim and swap the class name — there's no field-specific behavior to test here; that belongs in the generic-importer spec (Step 7) instead.
+
+**Run it before touching the model.** `bundle exec rspec spec/models/certification_summary_spec.rb` should fail red with no `belongs_to` / `validates` yet — then fill in the model and rerun until green. Same Red → Green discipline `CLAUDE.md` mandates for every model, concern, and job in this app.
+
+**Once it's green, re-annotate.** Run `bin/rails db:migrate` again — harmless with nothing pending, but it still fires the `annotaterb` hook (`lib/tasks/annotate_rb.rake`) — or run `bundle exec annotaterb models` directly. `.annotaterb.yml` has `exclude_factories: false` and `exclude_tests: false`, so this stamps the `# == Schema Information` block onto the factory and spec files too, not just the model.
+
 ---
 
 ## Step 2 — Register the new source file  (Path A only)
@@ -122,19 +188,23 @@ FILE_EXTENSIONS = {
 }.freeze
 ```
 
-### The three-name rule (get this exactly right)
+### One filename, three places
 
-One string ties everything together. These **three must match character-for-character**:
+Start from the file's name in the S3 bucket — say `my_new_file.csv` — and strip the extension: `my_new_file`. Use that exact string, unchanged, in three places:
 
-1. the key in `FILE_IMPORTERS` / `FILE_EXTENSIONS` above (`my_new_file`),
-2. the `source: {file: my_new_file, ...}` value you'll write in Step 3,
-3. the **object name in the S3 bucket**, minus extension — the importer fetches `"<ETL_SOURCE_URL>/my_new_file.csv"`.
-
-If any of the three disagree, you get **no error** — just a 404 on fetch or zero rows loaded. When an import "does nothing," check this first.
+1. The `FILE_IMPORTERS` / `FILE_EXTENSIONS` keys above.
+2. The `source: {file: my_new_file, ...}` value you'll write in `fields.yml` (Step 3) — this is what actually turns the registration into a working import.
+3. The S3 object name itself — the importer fetches `"<ETL_SOURCE_URL>/my_new_file.csv"` literally, so the bucket filename has to match too.
 
 > **Getting the file into the bucket:** the importer reads over HTTP from `ENV["ETL_SOURCE_URL"]` (the staged-data S3 bucket; see `.env` / `.env.example`). A *new* file has to be uploaded there first, named `my_new_file.csv`.
 
-There **is** one backstop: `spec/services/etl/importer_coverage_spec.rb` fails if you register a file here but forget to give it `source:` blocks in the manifest (Step 3) — so a registered-but-unwired file won't pass `bin/ci`. Nothing catches the reverse (a file you never register), which is why the three-name rule matters.
+Get any of the three wrong and there's **no error** — just a 404 on fetch or zero rows loaded. If an import "does nothing," this is the first thing to check.
+
+**Expect a failure here, and that's fine.** Right after this step — file registered, but `fields.yml` not touched yet — run `bundle exec rspec spec/services/etl/importer_coverage_spec.rb`. It fails, something like:
+```
+awia_certification: expected exactly one of generic(etl_mapping)=false, custom_imports=false
+```
+That's the backstop working as intended: a file can't be registered here and silently left unwired from the manifest. It goes green the moment Step 3 adds the `source:` block — nothing to fix yet, just confirmation you're mid-flow.
 
 Skip this entire step for Paths B, C, D — the file is already registered (B, C) or handled by a custom importer already in the map (D).
 
@@ -152,17 +222,25 @@ poverty_rate:
     file: epa_sabs_xwalk          #   must equal the FILE_IMPORTERS key (Step 2) AND the bucket object name
     header: "hh_below_pov_per"    #   the column's EXACT name in the CSV — always quoted, copied verbatim
     cast: decimal                 #   integer | decimal | string | score (0–1 → %) | bool
+  display:                        # omit if not shown as a table column
+    label: "Households below poverty line"   #   <th> header text — often differs from filter.label
+    sort: poverty_rate            #   sort param (omit → not sortable); may differ from key
+    format: pct                   #   str | num | dec | pct | cur | bool | check | link | copy
+    csv_label: "Households below the poverty line (%)"   #   verbose CSV header
   filter:                         # omit if not filterable
     kind: range                   #   range | radio | bool | multiselect
     coercion: decimal             #   range only: decimal | integer — how the slider values are cast
-    label: "Poverty rate"         #   the label shown in the filter menu
+    label: "Poverty rate"         #   the MENU label shown in the filter — often differs from display.label
     tooltip: poverty_rate         #   a key into config/tooltips.yml (Step 5); omit if none
     slider_label: "Percentage of households"   # range only: caption under the slider; omit if none
+  histogram:                      # omit if not histogram-capable
+    format: percent               #   percent | currency | count | percent_change
 ```
 
 Notes for a filter:
 - **`kind`** picks the control: `range` (numeric slider), `radio` (one-of), `bool` (yes/no), `multiselect` (many-of). A numeric column → almost always `range`.
 - **`range` needs `coercion`** so the min/max are cast correctly — don't omit it on numeric filters.
+- **`bool` on a non-boolean column needs `checked_value`.** The predicate defaults to comparing against a real boolean `true`; if the column is a two-value string instead (an enum-like column, e.g. `rra_certification`'s `Certified`/`Uncertified`), set `checked_value:` to whatever "checked" should compare against. See the `fields.yml` header for the shape and `rra_certification` for a real example.
 - **`radio` / `multiselect` need an `options:` list** instead of a `label`; `range` / `bool` never use `options`. See the `fields.yml` header for the `options:` shape.
 - **The URL param is permitted automatically.** `FieldRegistry.permit_arguments` (in `app/fields/field_registry.rb`) derives it from `filter.kind` — there is no permit code to edit.
 
@@ -175,7 +253,7 @@ Notes for a filter:
 
 ## Step 4 — `config/filter_layout.yml`: place the filter (if filterable)
 
-Add your field key to a category's `filters:` list. **Placement is not cosmetic — it sets the boolean logic:**
+Add your field key to a category's `filters:` list. **Placement determines more than where the filter appears — it also decides whether it ORs or ANDs with the filters around it:**
 
 - Filters in the **same category** are **OR**'d together.
 - Filters in **different categories** are **AND**'d together.
@@ -256,11 +334,13 @@ Demographic.first.poverty_rate                    # spot-check one
 
 Copy an existing field's assertions as your template — find one with the same `kind` / capability and adapt the key, label, and values.
 
+- **New model (brand-new table)** → `spec/models/<model>_spec.rb` — see Step 1's model/spec walkthrough for the base `associations` + `validations` pattern every satellite model follows.
 - **Filter behavior** → `spec/models/concerns/filterable_spec.rb`. This exercises `PublicWaterSystem.apply_filters(...)`; add a case like the existing ones (e.g. `apply_filters(symbology_field: "Modeled")`) asserting your filter includes/excludes the right rows.
 - **Filter renders in its menu** → `spec/requests/home_spec.rb` — the server-render specs that walk `filter_layout.yml` and assert each menu/tab renders.
 - **Column** → `spec/columns/table_layout_spec.rb`.
 - **The import actually maps your file correctly (Path A)** → `spec/services/etl/importers/generic_spec.rb`. Drop a small fixture at `spec/fixtures/etl/my_new_file.csv` (a header row + a couple of data rows), then add a `#parse` assertion proving `header → column → cast` — e.g. `expect(parse_fixture("my_new_file").first).to include(my_field: <expected cast value>)`. This is the spec that confirms your data will import correctly, with **no S3 and no live DB needed**.
 - **Import wiring backstop** → `spec/services/etl/importer_coverage_spec.rb` enforces that every registered file is either generic-with-`source:` or listed in `custom_imports:` (never both). A new Path-A file must satisfy it — it's the check that catches a file registered in Step 2 but not wired in Step 3.
+- **Brand-new table, exported** → no new test needed, but `bin/ci`'s `spec/exporters/public_water_system_exporter_spec.rb` and `spec/requests/exports_spec.rb` will fail loudly (`PG::UndefinedTable: missing FROM-clause entry`) if Step 1's export join list entry was skipped — that's the existing coverage catching it, not a gap to fill.
 
 ### 4. (Optional) Local dev data — how seeding works
 

--- a/docs/how_to/EDIT_EXISTING_DATA_FIELD.md
+++ b/docs/how_to/EDIT_EXISTING_DATA_FIELD.md
@@ -20,7 +20,7 @@ See also:
 | CSV export header | `fields.yml` → `display.csv_label` | |
 | Whether it's sortable / the sort param | `fields.yml` → `display.sort` | omit to make it unsortable |
 | Filter menu label | `fields.yml` → `filter.label` | distinct from `display.label` |
-| Filter kind (range / radio / bool / multiselect) | `fields.yml` → `filter.kind` | also revisit options / coercion |
+| Filter kind (range / radio / bool / multiselect) | `fields.yml` → `filter.kind` | also revisit options / coercion; switching to `bool` on a non-boolean column also needs `checked_value` |
 | Histogram format | `fields.yml` → `histogram.format` | |
 | Tooltip copy | `config/tooltips.yml` | manifest references it by key |
 | **Which menu / category a filter lives in** | `config/filter_layout.yml` | **changes AND/OR — see below** |
@@ -51,6 +51,8 @@ So moving a filter into another category, or splitting one category into two, **
 - **Change a format** → `fields.yml` `display.format` (and `histogram.format` if charted).
 - **Make a shown filter URL-only** → remove its key from the layout file. No flag needed — a filterable field absent from the layout is filterable by its param but hidden from the menu.
 - **Rename the field key** → touches the manifest key plus its references in both layout files (and any spec referencing the param). Treat it like a small remove + add; grep the old key first.
+- **Switch a filter to `kind: bool` on a non-boolean column** → also set `filter.checked_value` (see `ADD_NEW_DATA_FIELD.md` Step 3). Without it the predicate compares against a literal `true`, which either matches nothing or raises a Postgres type error against a string column.
+- **Add a Rails `enum` to an existing column** → only if something will actually consume the enum's *key* (a filter doing value translation, a dedicated display formatter — see `Demographic#most_common_rate_tier`). Otherwise the model's attribute reader returns the key instead of the stored value, silently breaking that field's table display. See `ADD_NEW_DATA_FIELD.md` Step 1 for the full explanation and the `CertificationSummary` example this app hit.
 
 ---
 

--- a/docs/how_to/EDIT_EXISTING_DATA_FIELD.md
+++ b/docs/how_to/EDIT_EXISTING_DATA_FIELD.md
@@ -52,7 +52,7 @@ So moving a filter into another category, or splitting one category into two, **
 - **Make a shown filter URL-only** → remove its key from the layout file. No flag needed — a filterable field absent from the layout is filterable by its param but hidden from the menu.
 - **Rename the field key** → touches the manifest key plus its references in both layout files (and any spec referencing the param). Treat it like a small remove + add; grep the old key first.
 - **Switch a filter to `kind: bool` on a non-boolean column** → also set `filter.checked_value` (see `ADD_NEW_DATA_FIELD.md` Step 3). Without it the predicate compares against a literal `true`, which either matches nothing or raises a Postgres type error against a string column.
-- **Add a Rails `enum` to an existing column** → only if something will actually consume the enum's *key* (a filter doing value translation, a dedicated display formatter — see `Demographic#most_common_rate_tier`). Otherwise the model's attribute reader returns the key instead of the stored value, silently breaking that field's table display. See `ADD_NEW_DATA_FIELD.md` Step 1 for the full explanation and the `CertificationSummary` example this app hit.
+- **Add a Rails `enum` to an existing column** → only if something will actually consume the enum's *key* (a filter doing value translation, a dedicated display formatter — see `Demographic#most_common_rate_tier`). Otherwise the model's attribute reader returns the key instead of the stored value, silently breaking that field's table display. See `ADD_NEW_DATA_FIELD.md` Step 1 for the full explanation.
 
 ---
 

--- a/docs/how_to/REMOVE_EXISTING_DATA_FIELD.md
+++ b/docs/how_to/REMOVE_EXISTING_DATA_FIELD.md
@@ -24,6 +24,26 @@ Nothing else is needed for a fully manifest-driven field: `permit_arguments`, `s
 
 ---
 
+## Removing a whole satellite table (not just a field)
+
+If the field you're removing was the *last* field on its satellite table, remove the table too —
+this mirrors `ADD_NEW_DATA_FIELD.md`'s "Brand-new table" subsection, in reverse:
+
+1. **The model** — delete `app/models/<model>.rb`.
+2. **The association** — remove the `has_one`/`has_many` line from `app/models/public_water_system.rb`.
+3. **The manifest's model registry** — remove the entry from `MODEL_CLASSES` in `app/fields/field_registry.rb`.
+4. **The export join list** — remove the `LEFT JOIN` line from `ASSOCIATION_JOINS` in
+   `app/exporters/public_water_system_exporter.rb`. This isn't optional cleanup: a stale join to a
+   dropped table raises `PG::UndefinedTable: relation does not exist` on the next export, the same
+   failure mode as forgetting to add it in the first place.
+5. **The factory and model spec** — delete `spec/factories/<table>.rb` and `spec/models/<model>_spec.rb`.
+6. **A migration** — `drop_table :<table_name>`.
+
+Each of these fails loudly if missed (`KeyError`, `PG::UndefinedTable`, or a `NameError` on the deleted
+constant) — none of it fails silently, so `bin/ci` will catch a skipped step.
+
+---
+
 ## The long version: removing a custom control kind
 
 A field with a **custom filter kind** (e.g. the removed Place filter, `kind: place`) has extra wiring that does *not* derive from the manifest. Grep the field/param name and expect to touch each of these:

--- a/docs/open_items/NICE_TO_HAVES.md
+++ b/docs/open_items/NICE_TO_HAVES.md
@@ -100,6 +100,18 @@ Would run post-import and report to a Slack channel or log. Useful for catching 
 
 ---
 
+### Filters: Case-insensitive string matching
+
+`Filterable`'s `radio`/`multiselect`/`bool` predicates use plain Arel `.eq`/`.in` — no case
+normalization. Filtering only works today because every manifest option value is hand-typed to
+match the DB's exact casing (confirmed: `apply_filters(gw_sw_code: "Groundwater")` returns 33,837
+rows, `apply_filters(gw_sw_code: "groundwater")` returns 0). Low priority — no known field has
+inconsistent casing today — but worth downcasing both sides of the comparison at some point so a
+manifest typo or a source-data casing drift fails loudly (wrong results now) rather than silently
+(zero results).
+
+---
+
 ### application.css: Confirm Defaults and Clean Up
 
 `app/assets/tailwind/application.css` has some leftover notes and may have unconfirmed

--- a/docs/open_items/POPULATION_SIZE_FILTER_COLUMN_MISMATCH.md
+++ b/docs/open_items/POPULATION_SIZE_FILTER_COLUMN_MISMATCH.md
@@ -1,0 +1,92 @@
+# Population size filter and table column reference different metrics
+
+## Context
+
+### What
+The "Population size" filter (checkboxes: "Very small," "Small," "Medium," "Large," "Very large")
+and the table column labeled "Population size" are backed by two unrelated fields. The filter
+narrows correctly against the data it targets, but the table gives no visible way to confirm that —
+a filtered row can show a "Population size" value far outside the bucket you just selected, making
+the filter look broken when it isn't.
+
+### Why
+Found during manual QA of the `Filterable` generalization on `feat/add-awai-fields-part-1-RRA`
+(unrelated to that work — confirmed present on `main` too). Left unaddressed, this will keep
+reading as a filter bug to anyone spot-checking results against the table, including future
+developers and users.
+
+---
+
+## Discovery
+
+### The two fields involved
+- **The filter** — `pop_cat_5` (`config/fields.yml`): `kind: multiselect`, filter-only (no
+  `display:` block), targets `public_water_systems.pop_cat_5`. This is EPA's own pre-bucketed
+  population-served category, loaded directly from the SABS source file
+  (`app/services/etl/importers/epa_sabs.rb`).
+- **The table column** — `total_population` (`config/fields.yml`), labeled "Population size" in
+  `display:`, targets `demographic.total_pop`. This is a census-based total population estimate,
+  loaded from the `epa_sabs_xwalk` source file's `total_pop` header. Different source file,
+  different metric, no defined relationship to `pop_cat_5`.
+
+### The filter is correct
+`pop_cat_5`'s buckets line up exactly with `population_served_count` — a column loaded in the same
+`epa_sabs.rb` import step, from the same source rows as `pop_cat_5` itself:
+
+| `pop_cat_5` bucket | `population_served_count` range | count |
+|---|---|---|
+| `<=500` | 0–500 | 22,472 |
+| `501-3,300` | 501–3,300 | 12,718 |
+| `3,301-10,000` | 3,301–10,000 | 4,912 |
+| `10,001-100,000` | 10,005–100,000 | 4,049 |
+| `>100,000` | 100,200–8,271,000 | 482 |
+| (null) | — | 9 |
+
+Every bucket's min/max lines up exactly with its option label — the filter is doing what it says.
+
+### The mismatch, demonstrated
+Systems with `pop_cat_5 = "<=500"` ("Very small, 500 or less") pulled by `total_population`
+descending:
+
+```
+CA4310027  pop_cat_5=<=500  total_population=1,890,988
+CA1910041  pop_cat_5=<=500  total_population=507,663
+CA3710042  pop_cat_5=<=500  total_population=399,557
+```
+
+A system EPA buckets as serving 500 or fewer people can show ~1.9M in the table's "Population
+size" column — because that column isn't measuring what the filter measures.
+
+### Where the correct number already lives
+`population_served_count` exists on `public_water_systems` (ETL-loaded, same import step as
+`pop_cat_5`) but has **no `config/fields.yml` entry** — not filterable (beyond the `pop_cat_5`
+bucket derived from it), not sortable, not shown in the main results table. It's already surfaced
+elsewhere under a different label:
+- PWS detail page overview (`app/views/public_water_systems/sections/_overview.html.erb`) —
+  "Population Served"
+- Map popup (`app/views/home/_map_popup_template.html.erb`) — "Customers served"
+
+So today, the only way to visually confirm the `pop_cat_5` filter is doing the right thing is to
+open a system's detail page or its map popup — not the main table.
+
+---
+
+## Implementation Guide
+
+Not started — this needs a product/labeling decision, not just a code change. Options, roughly in
+order of effort:
+
+1. **Add `population_served_count` to the manifest** as a displayable, sortable field
+   (`config/fields.yml` + `config/table_layout.yml`), so the table itself can show the number that
+   backs the `pop_cat_5` filter. Follow `docs/how_to/ADD_NEW_DATA_FIELD.md` — the column already
+   exists on `public_water_systems`, so this is closer to Step 3+ (manifest entry, table
+   placement) than a full new-field walkthrough.
+2. **Relabel `total_population`** away from "Population size" (e.g. "Total population (census)")
+   so its adjacency to the `pop_cat_5` filter's "Population size" label stops implying a
+   relationship that doesn't exist.
+3. Do both — clarifies the existing column's meaning and gives users a way to verify the filter
+   without leaving the table.
+
+---
+
+> **Cleanup:** Delete this file when resolved. Reference the closing PR in the commit message.

--- a/spec/exporters/public_water_system_exporter_spec.rb
+++ b/spec/exporters/public_water_system_exporter_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe PublicWaterSystemExporter do
       expect(rows[1]).to include("Test Water Co")
     end
 
+    it "exports a field's own column value, not a different same-model column" do
+      # Regression check: symbology_field and service_area_type are distinct columns on the same
+      # table; a stale db_column mapping previously made "Boundary type" export service_area_type's
+      # value instead of symbology_field's.
+      boundary_type_index = rows.first.index("Boundary type")
+      expect(rows[1][boundary_type_index]).to eq(pws.symbology_field)
+    end
+
     it "preserves sort order from the scope" do
       create(:public_water_system, pws_name: "Alpha Water")
       scope = PublicWaterSystem.order(pws_name: :asc)

--- a/spec/models/concerns/filterable_spec.rb
+++ b/spec/models/concerns/filterable_spec.rb
@@ -478,6 +478,28 @@ RSpec.describe Filterable, type: :model do
       end
     end
 
+    context "bool filters with a custom checked_value" do
+      # Synthetic field, not from the manifest — proves checked_value works on any column, without needing a field that declares it yet.
+      let(:field) do
+        FieldDefinition.new(
+          key: :test_bool_field, model: :public_water_system, table: :public_water_systems,
+          db_column: :gw_sw_code, source: nil, display: nil,
+          filter: {kind: :bool, param: :test_bool_field, checked_value: "Groundwater"}, histogram: nil
+        )
+      end
+
+      it "compares against the configured value instead of a literal true" do
+        groundwater = create(:public_water_system, gw_sw_code: "Groundwater")
+        surface = create(:public_water_system, gw_sw_code: "Surface Water")
+        params = {test_bool_field: "Groundwater"}
+
+        expect(PublicWaterSystem.send(:filter_active?, field, params)).to be true
+        results = PublicWaterSystem.where(PublicWaterSystem.send(:filter_predicate, field, params))
+        expect(results).to include(groundwater)
+        expect(results).not_to include(surface)
+      end
+    end
+
     context "funding filters" do
       it "filters by total_srf_assistance_min" do
         low_funded = create(:public_water_system)


### PR DESCRIPTION
## Summary

Split out of the `awia_certification`/`rra_certification` how-to branch — these are standalone, generic `Filterable` mechanism changes that don't depend on any unmerged feature work.

- **Generalize `Filterable`** so `radio` and `multiselect` filters run through the same generic `category_groups` → `filter_active?` / `filter_predicate` path as `range`/`bool`, instead of being hand-rolled in `apply_direct_filters`. This lets a future filter on a *joined* table use `radio`/`multiselect` without adding new custom code — the previous hardcoded version only supported those kinds on the base `public_water_systems` table.
  - Verified this is behavior-preserving for every field it currently touches (`gw_sw_code`, `owner_type`, `primacy_type`, `pop_cat_5`, `symbology_field`): each is the sole filter in its own `filter_layout.yml` category today, so "OR within category" is OR-of-one — identical to the old always-AND behavior. It only *enables* future multi-filter categories.
- **Add `filter.checked_value`** to the `bool` kind, so a checkbox can target any column value (e.g. `"Certified"`), not just literal Postgres `true`. No existing field uses it yet — it's infrastructure for the follow-up branch.
- **Fix `symbology_field`'s stray `db_column: service_area_type`** (pre-existing on `main`, unrelated to any of the above): `symbology_field` has no `source:` block (populated by the custom `EpaSabs` importer) and is read directly by both the filter and table display, so `db_column` was silently used *only* by CSV/GeoJSON export — meaning the exported "Boundary type" column pulled from a different, unrelated column than what the UI showed. Fixed by removing the stray key.
- **Doc updates** to `docs/how_to/*.md` reflecting the above: `checked_value` documented in Add/Edit how-tos, a new "removing a whole satellite table" section, and a warning that `db_column` only affects import/export (never table display) plus the export-value-assertion spec pattern that catches a wrong one.

## Test plan

- [x] `bundle exec rspec` — 1105 examples, 0 failures
- [x] `standardrb` — clean
- [x] Confirmed the `symbology_field` export-value spec fails on the old code (reproduced `"Residential Area"` vs `"System Sourced"`) and passes on the fix
- [ ] Manual smoke test in browser (see below) — not yet done, no browser tool in this environment

### Manual testing still needed
- Toggle each real bool filter (Has source protection, Wholesaler, School or daycare, Open violations) — template changed, confirm all still filter correctly
- Radio filters now on the generic path: Source type (`gw_sw_code`), Boundary type (`symbology_field`)
- Multiselect filters now on the generic path: Ownership (`owner_type`, incl. select-all/deselect-all), Authority (`primacy_type`), Population size (`pop_cat_5`) — confirm OR-within-filter
- Cross-category AND still holds (e.g. state + Source type together narrows results)
- Export a CSV and confirm the "Boundary type" column matches the table, not a stale value
- Reset-all clears every filter type correctly